### PR TITLE
fix: remove tslint error in native app

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,8 @@
 module.exports = {
-  extends: ["expo", "prettier","expo/typescript"],
+  extends: ["expo", "prettier"],
   plugins: ["prettier"],
   rules: {
     "prettier/prettier": "warn",
+    "no-undef": "warn",
   },
 };


### PR DESCRIPTION
 Convert tslint error to a warning in the native app.