### PR TITLE
fix(layout): remove Header from Login and Signup pages (#295)

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import * as React from "react";
 import { AppRouterCacheProvider } from "@mui/material-nextjs/v14-appRouter";
 import { ThemeProvider } from "@mui/material/styles";
@@ -6,17 +8,25 @@ import theme from "@/theme";
 import { Container } from "@mui/material";
 import Header from "@/components/header/Header";
 import BottomNavigationBar from "@/components/navigation/BottomNavigatorBar";
+import { usePathname } from "next/navigation";
 
 export default function RootLayout(props: { children: React.ReactNode }) {
+  const pathname = usePathname();
+
+  const authRoutes = ["/login", "/signup"];
+
+  // Check if the current route is an authentication page
+  const isAuthPage = authRoutes.includes(pathname ?? "");
+
   return (
     <html lang="en">
       <body>
         <AppRouterCacheProvider options={{ enableCssLayer: true }}>
           <ThemeProvider theme={theme}>
             <CssBaseline />
-            <Header />
+            {!isAuthPage && <Header />}
             <Container maxWidth="sm">{props.children}</Container>
-            <BottomNavigationBar />
+            {!isAuthPage && <BottomNavigationBar />}
           </ThemeProvider>
         </AppRouterCacheProvider>
       </body>


### PR DESCRIPTION
<!--
---
name: "Monorepo Contribution"
about: "Template for contributions in a monorepo with apps and packages folders"
title: "[Feature/Bug] - Title"
labels: ["contribution"]
assignees: ""  # Leave blank if no specific assignee
---
-->

### Description
This PR removes the Header component from the Login and Signup pages as per the requirement in issue #295. It ensures better user experience and prepares for future scalability when adding new authentication pages.

**Fixes**: #295  
or  
**Resolves**: # (issue number)

---

### Changes Made
- [ ] Changes in **`apps`** folder (specify the app and briefly describe the changes):
  - [x] `Web`
  - [ ] `Native`

- [ ] Changes in **`packages`** folder (specify the package and briefly describe the changes):
  - [ ] `Core`

---

### Type of Change
- [x] 🐛 **Bug fix** (non-breaking change which fixes an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [] 💥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 **Documentation update** (changes)

---

## Screenshots
|       Before        |       After        |
| :-----------------: | :----------------: |
| "screenshot before" | "screenshot after" |
---

### How Has This Been Tested?
- [ ] Cypress integration
- [ ] Cypress component tests
- [ ] Jest unit tests

---

### Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

---

### Additional Comments
*(Optional) Add any additional comments or notes for reviewers here.*
