### PR TITLE
chore: ignore expo modules in the build

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -2,5 +2,15 @@
 const nextConfig = {
   reactStrictMode: true,
   transpilePackages: ["wallet_state"],
+  webpack: (config, { isServer }) => {
+    // Ignore specific modules in the build
+    config.externals = [
+      ...(config.externals || []),
+      "expo-constants",
+      "expo-modules-core",
+    ];
+
+    return config;
+  },
 };
 module.exports = nextConfig;


### PR DESCRIPTION
<!--

name: "Monorepo Contribution" about: "Template for contributions in a monorepo
with apps and packages folders" title: "[Feature/Bug] - Title" labels:
["contribution"] assignees: "" # Leave blank if no specific assignee

---

-->

# Description
Ignore the expo-constant and expo-module-core module in the build  configuration of nextjs app

resolves #413



