### PR TITLE
Issue #425 fix(signup): confirm password field was not fillable 

### DIFF
--- a/apps/web/src/app/(auth)/signup/page.tsx
+++ b/apps/web/src/app/(auth)/signup/page.tsx
@@ -128,7 +128,7 @@ export default function SignUp() {
           />
           <CustomTextField
             label="Confirm password"
-            name="confirmpassword"
+            name="confirmPassword"
             type="password"
             value={formData.confirmPassword}
             handleChange={handleChange}


### PR DESCRIPTION
The confirm password field on the Sign Up page was not accepting input due to a `name` attribute mismatch. This has been resolved by correcting the name to match the corresponding key in the form state (`confirmPassword`).

<!--

name: "Aniket Chopade"
about: "Bug fix for the Web app in a monorepo — corrects confirm password field behavior on Sign Up page."
title: "[Bug] - Confirm password field was not fillable on Sign Up page"
labels: ["contribution", "bug"]
assignees: "" # Leave blank if no specific assignee
---

-->

# Description

Fixes an issue where the confirm password field on the Sign Up page was unresponsive due to a name mismatch between the input field and form state.


**Fixes**: #425

---

## Changes Made

- [x] Changes in **`apps`** folder:
  - [x] `Web`: Updated the `name` attribute of the confirm password input field in the `SignUp` component to match the key in the form state (`confirmPassword`).


### Type of Change

- [ ] 🐛 **Bug fix** (non-breaking change which fixes an issue)

---

---

### How Has This Been Tested?

- [x] Manually tested in browser to ensure confirm password field accepts input

---

### Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

