### PR TITLE
feat: added notifications header for the native app

### DIFF
--- a/apps/native/app/(tabs)/notifications/index.tsx
+++ b/apps/native/app/(tabs)/notifications/index.tsx
@@ -1,34 +1,88 @@
-import React from "react";
-import { StyleSheet, Text, View } from "react-native";
+import {
+  Ionicons,
+  MaterialCommunityIcons,
+  MaterialIcons,
+} from "@expo/vector-icons";
+import { router, Stack, useRouter } from "expo-router";
+import { TouchableOpacity, View, Text, StyleSheet } from "react-native";
 
 export default function NotificationsLayout() {
   return (
-    <View>
-      <Text>Notfications</Text>
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <View style={styles.side}>
+          <TouchableOpacity
+            onPress={() => {
+              router.push("/");
+            }}
+            style={styles.iconButton}>
+            <Ionicons name="arrow-back" size={24} color="black" />
+          </TouchableOpacity>
+        </View>
+
+        <Text style={styles.title}>Notifications</Text>
+
+        <View style={styles.side}>
+          <TouchableOpacity style={styles.iconButton}>
+            <Ionicons name="settings-outline" size={24} color="black" />
+          </TouchableOpacity>
+        </View>
+      </View>
+
+      <View style={styles.body}>
+        <MaterialCommunityIcons name="wallet-outline" size={80} color="gray" />
+        <Text style={styles.message}>
+          Come back here to get information about recent transactions, mentions,
+          and much more.
+        </Text>
+      </View>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  safeArea: {
-    flex: 1,
-    backgroundColor: "#f5f5f5",
-  },
   container: {
     flex: 1,
-    justifyContent: "space-between",
+    backgroundColor: "#fff",
+  },
+  header: {
+    height: 60,
+    flexDirection: "row",
     alignItems: "center",
-    padding: 32,
-    backgroundColor: "#f5f5f5",
+    justifyContent: "space-between",
+    paddingHorizontal: 16,
+    position: "relative",
   },
-  content: {
-    marginTop: 32,
+  side: {
+    width: 40, // same width left and right to reserve space
+    alignItems: "center",
+    justifyContent: "center",
   },
-  commonText: {
+  iconButton: {
+    padding: 8,
+    borderRadius: 20,
+  },
+  title: {
+    position: "absolute",
+    left: 0,
+    right: 0,
     textAlign: "center",
-    color: "#222629DE",
-  },
-  description: {
     fontSize: 20,
+    fontWeight: "bold",
+    color: "#333",
+  },
+  body: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: 24,
+    marginTop: "-20%",
+  },
+  message: {
+    marginTop: 16,
+    textAlign: "center",
+    color: "gray",
+    fontSize: 16,
+    lineHeight: 22,
   },
 });


### PR DESCRIPTION
<!--
name: "Monorepo Contribution"
about: "Template for contributions in a monorepo with apps and packages folders"
title: "[Feature] - Added Notifications Header in Native App"
labels: ["contribution"]
assignees: "sanketh-uta"
-->

# Description

Added a Notifications Header component in the Native app.  
This includes back navigation and settings icons, styled using React Native and vector icons.

**Fixes**: N/A

---

## Changes Made

- [x] Changes in **`apps`** folder:

  - [x] `Native`: Added a new header section in the notifications screen with layout, icons, and navigation behavior to exactly match the Figma design 

- [ ] Changes in **`packages`** folder:
  - [ ] `Core`

---

### Type of Change

- [ ] 🐛 **Bug fix**
- [x] ✨ **New feature**
- [ ] 💥 **Breaking change**
- [ ] 📝 **Documentation update**

---

#### Screenshots

|       Before        |       After        |
| :-----------------: | :----------------: |
| _(Notification Screen Doesnot exist)_ | 
<img width="357" alt="image" src="https://github.com/user-attachments/assets/19232f0b-8c5b-4519-bef2-09ea1c3e37f7" />




### How Has This Been Tested?

- [x] Manual testing on iOS simulator and Android emulator
- [ ] Cypress integration
- [ ] Cypress component tests
- [ ] Jest unit tests

---

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

---

### Additional Comments

Tested on both iOS and Android environments.  
Used `Ionicons` and `MaterialCommunityIcons` from Expo.  
Open to suggestions for improved navigation or style enhancements.
