### PR TITLE
fix: correct Confirm Password input name to match state key for contr…

### DIFF
--- a/apps/web/src/app/(auth)/signup/page.tsx
+++ b/apps/web/src/app/(auth)/signup/page.tsx
@@ -39,6 +39,8 @@ export default function SignUp() {
     return emailRegex.test(email);
   };
 
+  console.log(formData?.confirmPassword);
+
   // Password validation (at least 8 characters)
   const validatePassword = (password: string) => {
     return password.length >= 8; // At least 8 characters
@@ -128,7 +130,7 @@ export default function SignUp() {
           />
           <CustomTextField
             label="Confirm password"
-            name="confirmpassword"
+            name="confirmPassword"
             type="password"
             value={formData.confirmPassword}
             handleChange={handleChange}

--- a/apps/web/src/app/(auth)/signup/page.tsx
+++ b/apps/web/src/app/(auth)/signup/page.tsx
@@ -39,8 +39,6 @@ export default function SignUp() {
     return emailRegex.test(email);
   };
 
-  console.log(formData?.confirmPassword);
-
   // Password validation (at least 8 characters)
   const validatePassword = (password: string) => {
     return password.length >= 8; // At least 8 characters


### PR DESCRIPTION
# Description

Fixed the issue where the "Confirm Password" input field on the Sign Up page was unresponsive due to a mismatch between the input's `name` attribute and the state key controlling it. Renamed the input's `name` to exactly match the state key (`confirmPassword`), making it a properly controlled input.

**Fixes**: #425

---

## Changes Made

- [x] Changes in **`apps`** folder:

  - [x] `Web` — Corrected `Confirm Password` input field's `name` attribute on the Sign Up page

- [ ] Changes in **`packages`** folder:

  - [ ] `Core`

---

### Type of Change

- [x] 🐛 **Bug fix** (non-breaking change which fixes an issue)

---

### How Has This Been Tested?

- [ ] Cypress integration  
- [ ] Cypress component tests  
- [ ] Jest unit tests  
- [x] Manual testing in local dev environment  

---

### Checklist:

- [x] I have performed a self-review of my own code  
- [] I have commented my code, particularly in hard-to-understand areas  
- [ ] I have made corresponding changes to the documentation  
- [x] My changes generate no new warnings  
- [ ] I have added tests that prove my fix is effective or that my feature works  
- [ ] New and existing unit tests pass locally with my changes  
- [ ] Any dependent changes have been merged and published in downstream modules  

---

### Additional Comments

The fix ensures the Confirm Password field behaves as a controlled input and resolves the reported freezing issue on typing.
