### PR TITLE
feat(web): implement login and signup API calls with Jotai

### DIFF
--- a/apps/web/cypress.config.ts
+++ b/apps/web/cypress.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
   },
 
   e2e: {
+    baseUrl: "http://localhost:3000",
     setupNodeEvents(on, config) {
       // implement node event listeners here
     },

--- a/apps/web/cypress/e2e/login.cy.ts
+++ b/apps/web/cypress/e2e/login.cy.ts
@@ -1,0 +1,89 @@
+import {
+  SELECTORS,
+  loginWith,
+  expectLoginError,
+  expectSuccessfulLogin,
+  expectFormFieldError,
+  loadAuthFixture,
+} from "../support/auth-constants";
+
+describe("Login Page", () => {
+  // 📋 Load fixture data once before all tests
+  before(() => {
+    loadAuthFixture();
+  });
+
+  beforeEach(function () {
+    cy.visit(this.authData.routes.login);
+  });
+
+  describe("✅ Successful Login Flow", () => {
+    it("should authenticate and redirect to home with session persistence", function () {
+      loginWith(this.authData.users.validUser);
+      expectSuccessfulLogin(this.authData.routes.home);
+    });
+
+    it("should redirect to intended protected page after login", function () {
+      cy.visit(this.authData.routes.home);
+      cy.url().should("include", this.authData.routes.login);
+
+      loginWith(this.authData.users.validUser);
+      cy.location("pathname").should("eq", this.authData.routes.home);
+    });
+  });
+
+  describe("❌ Authentication Failures", () => {
+    it("should reject invalid credentials", function () {
+      loginWith(this.authData.users.invalidUser);
+      expectLoginError(this.authData.errorMessages.login.loginFailed);
+    });
+
+    it("should reject short username", function () {
+      loginWith(this.authData.users.shortUsername);
+      expectLoginError(this.authData.errorMessages.login.loginFailed);
+    });
+  });
+
+  describe("📝 Form Validation", () => {
+    it("should validate empty username", function () {
+      cy.getByData(SELECTORS.loginPassword).type(
+        this.authData.users.validUser.password,
+      );
+      cy.getByData(SELECTORS.loginSubmitButton).click();
+      expectFormFieldError(this.authData.errorMessages.login.emptyUsername);
+    });
+
+    it("should validate empty password", function () {
+      cy.getByData(SELECTORS.loginUsername).type(
+        this.authData.users.validUser.username,
+      );
+      cy.getByData(SELECTORS.loginSubmitButton).click();
+      expectFormFieldError(this.authData.errorMessages.login.emptyPassword);
+    });
+
+    it("should validate short password", function () {
+      loginWith(this.authData.users.shortPassword);
+      expectFormFieldError(this.authData.errorMessages.login.shortPassword);
+    });
+
+    it("should validate both empty fields simultaneously", function () {
+      cy.getByData(SELECTORS.loginSubmitButton).click();
+      expectFormFieldError(this.authData.errorMessages.login.emptyUsername);
+      expectFormFieldError(this.authData.errorMessages.login.emptyPassword);
+    });
+  });
+
+  describe("🔧 UI Functionality", () => {
+    it("should toggle password visibility", function () {
+      cy.getByData(SELECTORS.loginPassword).type(
+        this.authData.users.validUser.password,
+      );
+      cy.getByData(SELECTORS.passwordToggle).click();
+    });
+
+    it("should navigate to signup page", function () {
+      cy.getByData(SELECTORS.signupLink).click();
+      cy.location("pathname").should("eq", this.authData.routes.signup);
+    });
+  });
+});

--- a/apps/web/cypress/e2e/signup.cy.ts
+++ b/apps/web/cypress/e2e/signup.cy.ts
@@ -1,0 +1,99 @@
+import {
+  SELECTORS,
+  registerWith,
+  expectRegistrationSuccess,
+  expectValidationError,
+  generateUniqueEmail,
+  loadAuthFixture,
+} from "../support/auth-constants";
+
+describe("Register Page", () => {
+  before(() => {
+    loadAuthFixture();
+  });
+
+  beforeEach(function () {
+    cy.visit(this.authData.routes.signup);
+  });
+
+  describe("🎨 Form Display", () => {
+    it("should display the registration form with all required fields", () => {
+      cy.getByData(SELECTORS.signupForm).should("exist");
+      cy.getByData(SELECTORS.signupUsername).should("exist");
+      cy.getByData(SELECTORS.signupEmail).should("exist");
+      cy.getByData(SELECTORS.signupPassword).should("exist");
+      cy.getByData(SELECTORS.signupSubmitButton).should("exist");
+    });
+  });
+
+  describe("✅ Successful Registration", () => {
+    it("should register successfully with valid data", function () {
+      cy.intercept("POST", "**/api/auth/register", {
+        statusCode: 200,
+        body: {
+          message: this.authData.errorMessages.registration.registrationSuccess,
+        },
+      });
+
+      const uniqueEmail = generateUniqueEmail();
+      registerWith({
+        username: `${this.authData.registration.validRegistration.username}${Date.now()}`,
+        email: uniqueEmail,
+        password: this.authData.registration.validRegistration.password,
+      });
+      expectRegistrationSuccess(
+        this.authData.errorMessages.registration.registrationSuccess,
+      );
+    });
+  });
+
+  describe("❌ Failed Registration", () => {
+    it("should show an error when trying to register with an existing user name", function () {
+      const existingEmail = this.authData.registration.existingEmail.email;
+      const existingUsername =
+        this.authData.registration.existingEmail.username;
+      const existingPassword =
+        this.authData.registration.existingEmail.password;
+      registerWith({
+        username: existingUsername,
+        email: existingEmail,
+        password: existingPassword,
+      });
+      expectValidationError(
+        SELECTORS.signupError,
+        this.authData.errorMessages.registration.emailAlreadyExists,
+      );
+    });
+  });
+
+  describe("📝 Form Validation", () => {
+    it("should validate empty fields", function () {
+      cy.getByData(SELECTORS.signupSubmitButton).click();
+
+      // Assert all required field errors in a single step for clarity and maintainability
+      [
+        {
+          selector: SELECTORS.errorHelperText,
+          message: this.authData.errorMessages.registration.usernameRequired,
+        },
+        {
+          selector: SELECTORS.errorHelperText,
+          message: this.authData.errorMessages.registration.emailRequired,
+        },
+        {
+          selector: SELECTORS.errorHelperText,
+          message: this.authData.errorMessages.registration.passwordRequired,
+        },
+      ].forEach(({ selector, message }) => {
+        expectValidationError(selector, message);
+      });
+    });
+  });
+
+  describe("🔗 Navigation", () => {
+    it("should navigate to login page", function () {
+      cy.getByData(SELECTORS.loginLink).click();
+      cy.location("pathname").should("eq", this.authData.routes.login);
+    });
+  });
+});

--- a/apps/web/cypress/fixtures/auth-data.json
+++ b/apps/web/cypress/fixtures/auth-data.json
@@ -1,0 +1,75 @@
+{
+  "users": {
+    "validUser": {
+      "username": "demo",
+      "password": "demodemon"
+    },
+    "invalidUser": {
+      "username": "wronguser",
+      "password": "wrongpass"
+    },
+    "shortPassword": {
+      "username": "demo",
+      "password": "short"
+    },
+    "shortUsername": {
+      "username": "invs",
+      "password": "demodemon"
+    }
+  },
+  "registration": {
+    "validRegistration": {
+      "email": "test@example.com",
+      "username": "testuser",
+      "password": "Password123!"
+    },
+    "invalidEmail": {
+      "email": "invalid-email",
+      "username": "testuser",
+      "password": "Password123!",
+      "confirmPassword": "Password123!"
+    },
+    "mismatchedPasswords": {
+      "email": "test@example.com",
+      "username": "testuser",
+      "password": "Password123!",
+      "confirmPassword": "Password321!"
+    },
+    "weakPassword": {
+      "email": "test@example.com",
+      "username": "testuser",
+      "password": "123"
+    },
+    "existingEmail": {
+      "email": "test@example.com",
+      "username": "testuser",
+      "password": "Password123!"
+    }
+  },
+  "errorMessages": {
+    "login": {
+      "loginFailed": "Login failed. Please try again.",
+      "emptyUsername": "\"username\" is not allowed to be empty",
+      "emptyPassword": "\"password\" is not allowed to be empty",
+      "shortPassword": "Password must be at least 6 characters long"
+    },
+    "registration": {
+      "emailRequired": "Email is required",
+      "usernameRequired": "Username is required",
+      "passwordRequired": "Password is required",
+      "invalidEmail": "Enter a valid email",
+      "passwordsMismatch": "Passwords do not match",
+      "registrationSuccess": "User created successfully!",
+      "existingEmail": "Email already exists",
+      "existingUsername": "Username already exists",
+      "emailAlreadyExists": "User exists with same email",
+      "usernameAlreadyExists": "User exists with same username",
+      "errorUser": "Error creating user"
+    }
+  },
+  "routes": {
+    "login": "/login",
+    "signup": "/signup",
+    "home": "/home"
+  }
+}

--- a/apps/web/cypress/support/auth-constants.ts
+++ b/apps/web/cypress/support/auth-constants.ts
@@ -1,0 +1,116 @@
+// 🚀 Shared Auth Constants & Helpers for 10x Development with Fixtures
+
+import sinonChai from "cypress/types/sinon-chai";
+
+// Static Selectors (don't change often, keep in constants)
+export const SELECTORS = {
+  // Login selectors
+  loginUsername: "login-username",
+  loginPassword: "login-password",
+  loginSubmitButton: "login-submit-button",
+  loginError: "login-error",
+  passwordToggle: "toggle-password-visibility",
+  loginLink: "login-link",
+
+  // Registration selectors
+  signupForm: "signup-form",
+  signupEmail: "signup-email",
+  signupUsername: "signup-username",
+  signupPassword: "signup-password",
+  signupConfirmPassword: "signup-confirm-password",
+  signupSubmitButton: "signup-submit-button",
+  signupLink: "signup-link",
+  signupError: "signup-error",
+  signupSuccess: "signup-success",
+
+  // Shared selectors
+  errorHelperText: "error-helper-text",
+  homePageElement: "home-page-element",
+} as const;
+
+// 🔧 Auth Helper Functions with Fixture Support
+
+// Login helpers
+export const loginWith = (credentials: {
+  username: string;
+  password: string;
+}) => {
+  cy.getByData(SELECTORS.loginUsername).type(credentials.username);
+  cy.getByData(SELECTORS.loginPassword).type(credentials.password);
+  cy.getByData(SELECTORS.loginSubmitButton).click();
+};
+
+export const expectLoginError = (message: string) => {
+  cy.getByData(SELECTORS.loginError)
+    .should("be.visible")
+    .and("contain", message);
+};
+
+export const expectSuccessfulLogin = (homeRoute: string = "/home") => {
+  cy.window()
+    .its("sessionStorage.token")
+    .should("be.a", "string")
+    .and("not.be.empty");
+  cy.location("pathname", { timeout: 20000 }).should("eq", homeRoute);
+  cy.getByData(SELECTORS.homePageElement).should("be.visible");
+};
+
+// Registration helpers
+export const registerWith = (data: {
+  email?: string;
+  username?: string;
+  password: string;
+  confirmPassword?: string;
+}) => {
+  if (typeof data.email === "string") {
+    cy.getByData(SELECTORS.signupEmail).type(data.email);
+  }
+  if (typeof data.username === "string") {
+    cy.getByData(SELECTORS.signupUsername).type(data.username);
+  }
+  cy.getByData(SELECTORS.signupPassword).type(data.password);
+  if (typeof data.confirmPassword === "string") {
+    cy.getByData(SELECTORS.signupConfirmPassword).type(data.confirmPassword);
+  }
+  cy.getByData(SELECTORS.signupSubmitButton).click();
+};
+
+export const expectRegistrationSuccess = (
+  message: string = "User created successfully!",
+) => {
+  cy.getByData(SELECTORS.signupSuccess)
+    .should("be.visible")
+    .and("contain", message);
+};
+
+// Shared validation helpers
+export const expectValidationError = (selector: string, message: string) => {
+  cy.getByData(selector).should("be.visible").and("contain", message);
+};
+
+export const expectFormFieldError = (message: string) => {
+  cy.getByData(SELECTORS.errorHelperText)
+    .should("be.visible")
+    .and("contain", message);
+};
+
+// Utility functions
+export const generateUniqueEmail = () => `testuser${Date.now()}@example.com`;
+
+export const clearAuthSession = () => {
+  cy.window().then(win => {
+    win.sessionStorage.clear();
+    win.localStorage.clear();
+  });
+};
+
+// 🎯 Fixture Helper Functions for 10x Development
+export const loadAuthFixture = () => {
+  return cy.fixture("auth-data").as("authData");
+};
+
+export const getFixtureData = (path: string) => {
+  return cy.get("@authData").then((data: any) => {
+    return path.split(".").reduce((obj, key) => obj[key], data);
+  });
+};

--- a/apps/web/cypress/support/e2e.ts
+++ b/apps/web/cypress/support/e2e.ts
@@ -16,5 +16,17 @@
 // Import commands.js using ES2015 syntax:
 import "./commands";
 
-// Alternatively you can use CommonJS syntax:
-// require('./commands')
+/// <reference types="cypress" />
+
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      getByData(dataTestAttribute: string): Chainable<JQuery<HTMLElement>>;
+    }
+  }
+}
+export {};
+
+Cypress.Commands.add("getByData", selector => {
+  return cy.get(`[data-test=${selector}]`);
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,12 +11,12 @@
     "pre-commit": "yarn pre-commit",
     "lint-staged": "yarn lint-staged",
     "cy:component": "cypress run --component",
-    "cy:e2e": "cypress run --e2e",
+    "cy:e2e": "start-server-and-test dev http://localhost:3000 \"cypress open --e2e\"",
+    "cy:e2e-headless": "start-server-and-test dev http://localhost:3000 \"cypress run --e2e\"",
     "cy:debug": "cypress run --component --headed",
     "cy:open": "cypress open"
   },
   "dependencies": {
-    "core": "1.0.0",
     "@emotion/cache": "11.13.1",
     "@emotion/react": "11.13.0",
     "@emotion/styled": "11.13.0",
@@ -28,6 +28,7 @@
     "@mui/utils": "6.0.2",
     "@mui/x-date-pickers": "^6.9.1",
     "@types/react-no-ssr": "^1.1.7",
+    "core": "1.0.0",
     "date-fns": "^2.30.0",
     "dayjs": "^1.11.9",
     "jotai": "^2.9.0",
@@ -43,6 +44,7 @@
     "eslint": "latest",
     "eslint-config-next": "latest",
     "prettier": "^3.4.2",
+    "start-server-and-test": "^2.0.12",
     "typescript": "latest"
   }
 }

--- a/apps/web/src/app/(protected)/home/page.tsx
+++ b/apps/web/src/app/(protected)/home/page.tsx
@@ -12,9 +12,9 @@ const activityData = [
   { title: "Greenstand", amount: -200, status: "Sent" },
 ];
 
-export default function Home() {
+export default function Page() {
   return (
-    <Container maxWidth="lg" sx={{ mt: 1 }}>
+    <Container maxWidth="lg" sx={{ mt: 1 }} data-test="home-page-element">
       <Box
         display="flex"
         flexDirection="row"

--- a/apps/web/src/app/(protected)/layout.tsx
+++ b/apps/web/src/app/(protected)/layout.tsx
@@ -1,37 +1,73 @@
 "use client";
 
-import { useRouter } from "next/navigation";
+import { useAtom } from "jotai";
 import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
 import LoadingSpinner from "@/components/LoadingSpinner";
+import { tokenAtom } from "core";
+import Header from "@/components/header/Header";
+import BottomNavigationBar from "@/components/navigation/BottomNavigatorBar";
 
 export default function ProtectedLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const [mounted, setMounted] = useState(false);
+  const [token, setToken] = useAtom(tokenAtom);
+  const [checked, setChecked] = useState(false);
   const router = useRouter();
-  const [isLoading, setIsLoading] = useState(true);
-  const [isAuthenticated, setIsAuthenticated] = useState(false);
 
   useEffect(() => {
-    const token = sessionStorage.getItem("token");
+    setMounted(true);
+  }, []);
 
-    if (!token) {
-      router.replace("/login");
-    } else {
-      setIsAuthenticated(true);
+  useEffect(() => {
+    if (mounted) {
+      setChecked(true);
     }
+  }, [mounted, token]);
 
-    setIsLoading(false);
-  }, [router]);
+  useEffect(() => {
+    if (checked && !token) {
+      router.replace("/login");
+    }
+  }, [checked, token, router]);
 
-  if (isLoading) {
-    return <LoadingSpinner />;
-  }
+  useEffect(() => {
+    const onStorage = (e: StorageEvent) => {
+      if (e.storageArea === sessionStorage) {
+        if (e.key === "token" && e.newValue === null) {
+          setToken(null);
+          router.replace("/login");
+        } else if (e.key === null) {
+          setToken(null);
+          router.replace("/login");
+        }
+      }
+    };
+    window.addEventListener("storage", onStorage);
+    return () => window.removeEventListener("storage", onStorage);
+  }, [router, setToken]);
 
-  if (!isAuthenticated) {
-    return null;
-  }
+  useEffect(() => {
+    const interval = setInterval(() => {
+      const currentToken = sessionStorage.getItem("token");
+      if (token && !currentToken) {
+        setToken(null);
+        router.replace("/login");
+      }
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [token, router, setToken]);
 
-  return <>{children}</>;
+  if (!mounted || !checked || !token) return <LoadingSpinner />;
+
+  return (
+    <>
+      <Header />
+      {children}
+      <BottomNavigationBar />
+    </>
+  );
 }

--- a/apps/web/src/app/(public)/layout.tsx
+++ b/apps/web/src/app/(public)/layout.tsx
@@ -1,13 +1,38 @@
 "use client";
 
 import { useEffect } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, usePathname } from "next/navigation";
 import { Container } from "@mui/material";
+import { tokenAtom } from "core";
+import { useAtom } from "jotai";
 
-export default function PublicLayout({
+const PublicLayout: React.FC<{ children: React.ReactNode }> = ({
   children,
-}: {
-  children: React.ReactNode;
-}) {
+}) => {
+  const [token, setToken] = useAtom(tokenAtom);
+  const router = useRouter();
+  const pathname = usePathname();
+
+  useEffect(() => {
+    if (token && pathname !== "/home") {
+      router.replace("/home");
+    } else if (!token && !["/login", "/signup"].includes(pathname ?? "")) {
+      router.replace("/login");
+    }
+  }, [token, pathname, router]);
+
+  useEffect(() => {
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === "token" && e.newValue === null) {
+        setToken(null);
+        router.replace("/login");
+      }
+    };
+    window.addEventListener("storage", onStorage);
+    return () => window.removeEventListener("storage", onStorage);
+  }, [router, setToken]);
+
   return <Container maxWidth="sm">{children}</Container>;
-}
+};
+
+export default PublicLayout;

--- a/apps/web/src/app/(public)/login/page.tsx
+++ b/apps/web/src/app/(public)/login/page.tsx
@@ -1,119 +1,124 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
+import { useState, ChangeEvent, FormEvent } from "react";
 import {
   Email as EmailIcon,
   Facebook as FacebookIcon,
   GitHub as GitHubIcon,
 } from "@mui/icons-material";
-import Link from "@mui/material/Link";
+import { Box, Typography, Link } from "@mui/material";
 import NextLink from "next/link";
+import { useRouter } from "next/navigation";
+import { useSetAtom } from "jotai";
 
 import Wrapper from "@/components/common/Wrapper";
+import Logo from "@/components/common/Logo";
+import CenteredColumnBox from "@/components/common/CenteredColumnBox";
 import CustomHeadingTitle from "@/components/common/CustomHeadingTitle";
 import CustomTextField from "@/components/common/CustomTextFieldProps";
-import { Box, Typography } from "@mui/material";
 import CustomSubmitButton from "@/components/common/CustomSubmitButton";
 import SocialButtons from "@/components/common/SocialButtons";
 import TermsSection from "@/components/common/TermsSection";
-import CenteredColumnBox from "@/components/common/CenteredColumnBox";
-import Logo from "@/components/common/Logo";
-import { useRouter } from "next/navigation";
 
-export default function Login() {
-  const [formData, setFormData] = useState({
-    username: "demo",
-    password: "demodemon",
-  });
-  const [error, setError] = useState("");
-  const [isButtonDisabled, setIsButtonDisabled] = useState(true);
+import { loginAtom, tokenAtom } from "core";
 
+const Login = () => {
   const router = useRouter();
+  const loginUser = useSetAtom(loginAtom);
+  const setToken = useSetAtom(tokenAtom);
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setFormData({ ...formData, [e.target.name]: e.target.value });
+  const [formState, setFormState] = useState({ username: "", password: "" });
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setFormState(prev => ({ ...prev, [name]: value }));
   };
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    setError("");
+    setIsSubmitting(true);
+    setFieldErrors({});
 
     try {
-      const res = await fetch(
-        `${process.env.NEXT_PUBLIC_BASE_URL}/api/auth/login`,
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            username: formData.username,
-            password: formData.password,
-          }),
-        },
-      );
+      const response = await loginUser(formState);
 
-      const data = await res.json();
-
-      if (!res.ok) {
-        setError(data.error_description || "Login failed");
+      if (response?.access_token) {
+        setToken(response.access_token);
+        router.push("/");
         return;
       }
 
-      localStorage.setItem("isAuth", "true");
+      if (response?.fieldErrors && typeof response.fieldErrors === "object") {
+        setFieldErrors(response.fieldErrors);
+        return;
+      }
 
-      localStorage.setItem("token", data.access_token);
-      //@ts-ignore
+      if (response?.message) {
+        setFieldErrors({ general: response.message });
+        return;
+      }
 
-      router.push("/home");
-    } catch (err) {
-      console.log(err);
-      setError("Something went wrong. Please try again.");
+      setFieldErrors({ general: "Login failed. Please try again." });
+    } catch (err: any) {
+      const message =
+        err?.response?.data?.message ||
+        err?.message ||
+        "Something went wrong. Please try again.";
+      setFieldErrors({ general: message });
+      console.error("Login error:", err);
+    } finally {
+      setIsSubmitting(false);
     }
   };
-
-  useEffect(() => {
-    const isFormValid = formData.username !== "" && formData.password !== "";
-    setIsButtonDisabled(!isFormValid);
-  }, [formData]);
-
   return (
     <Wrapper>
       <CenteredColumnBox>
         <Logo />
         <CustomHeadingTitle title="Log in" />
+
         <form onSubmit={handleSubmit}>
           <CustomTextField
             label="Username"
             name="username"
-            value={formData.username}
-            handleChange={handleChange}
+            value={formState.username}
+            onChange={handleChange}
             type="text"
             required
+            helperText={fieldErrors.username}
+            testId="login-username"
           />
+
           <CustomTextField
             label="Password"
             name="password"
-            value={formData.password}
-            handleChange={handleChange}
+            value={formState.password}
+            onChange={handleChange}
             type="password"
             required
+            helperText={fieldErrors.password}
+            testId="login-password"
           />
-          {error && (
-            <Typography color="error" sx={{ mt: 1 }}>
-              {error}
+
+          {fieldErrors.general && (
+            <Typography
+              variant="body2"
+              color="error"
+              sx={{ mt: 1 }}
+              data-test="login-error">
+              {fieldErrors.general}
             </Typography>
           )}
-          <CustomSubmitButton text="Log In" isDisabled={isButtonDisabled} />
+
+          <CustomSubmitButton
+            text="Log In"
+            isDisabled={isSubmitting}
+            testId="login-submit-button"
+          />
         </form>
 
-        <Box
-          sx={{
-            my: 3,
-            display: "flex",
-            width: "100%",
-            justifyContent: "center",
-          }}>
+        <Box sx={{ my: 3, display: "flex", justifyContent: "center" }}>
           <Typography variant="body2">Or</Typography>
         </Box>
 
@@ -124,31 +129,22 @@ export default function Login() {
             display: "flex",
             flexDirection: "column",
           }}>
-          <SocialButtons
-            text="Login With Gmail"
-            type="submit"
-            icon={<EmailIcon />}
-          />
-          <SocialButtons
-            text="Login With Facebook"
-            type="submit"
-            icon={<FacebookIcon />}
-          />
-          <SocialButtons
-            text="Login With Github"
-            type="submit"
-            icon={<GitHubIcon />}
-          />
+          <SocialButtons text="Login With Gmail" icon={<EmailIcon />} />
+          <SocialButtons text="Login With Facebook" icon={<FacebookIcon />} />
+          <SocialButtons text="Login With GitHub" icon={<GitHubIcon />} />
 
           <Box sx={{ display: "flex", gap: "0.3rem" }}>
-            <Typography>Not have an Account?</Typography>
-            <Link href="/signup" component={NextLink}>
-              SignUp
+            <Typography>Don't have an account?</Typography>
+            <Link href="/signup" component={NextLink} data-test="signup-link">
+              Sign Up
             </Link>
           </Box>
+
           <TermsSection />
         </Box>
       </CenteredColumnBox>
     </Wrapper>
   );
-}
+};
+
+export default Login;

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -5,37 +5,15 @@ import { AppRouterCacheProvider } from "@mui/material-nextjs/v14-appRouter";
 import { ThemeProvider } from "@mui/material/styles";
 import CssBaseline from "@mui/material/CssBaseline";
 import theme from "@/theme";
-import { Container } from "@mui/material";
-import Header from "@/components/header/Header";
-import BottomNavigationBar from "@/components/navigation/BottomNavigatorBar";
-import { usePathname } from "next/navigation";
 
 export default function RootLayout(props: { children: React.ReactNode }) {
-  const pathname = usePathname();
-  const authRoutes = ["/login", "/signup"];
-
-  const [hasToken, setHasToken] = React.useState<boolean | null>(null);
-
-  React.useEffect(() => {
-    const token = sessionStorage.getItem("token");
-    setHasToken(!!token);
-  }, []);
-
-  // If token is not checked yet (null), avoid flicker on hydration
-  if (hasToken === null) return null;
-
-  const isAuthPage = authRoutes.includes(pathname ?? "");
-  const shouldShowLayout = !isAuthPage && hasToken;
-
   return (
     <html lang="en">
       <body style={{ backgroundColor: theme.palette.background.default }}>
         <AppRouterCacheProvider options={{ enableCssLayer: true }}>
           <ThemeProvider theme={theme}>
             <CssBaseline />
-            {shouldShowLayout && <Header />}
-            <Container maxWidth="sm">{props.children}</Container>
-            {shouldShowLayout && <BottomNavigationBar />}
+            {props.children}
           </ThemeProvider>
         </AppRouterCacheProvider>
       </body>

--- a/apps/web/src/components/common/CustomSubmitButton.tsx
+++ b/apps/web/src/components/common/CustomSubmitButton.tsx
@@ -8,12 +8,14 @@ interface SubmitButtonProps {
   isDisabled: boolean;
   onClick?: () => void;
   variant?: "text" | "outlined" | "contained"; // Add variant prop
+  testId?: string;
 }
 
 const CustomSubmitButton: React.FC<SubmitButtonProps> = ({
   text,
   isDisabled,
   onClick,
+  testId,
   variant = "contained", // Default to "contained" variant
 }) => {
   return (
@@ -24,7 +26,8 @@ const CustomSubmitButton: React.FC<SubmitButtonProps> = ({
       style={{
         marginTop: "1rem",
       }}
-      disabled={isDisabled}>
+      disabled={isDisabled}
+      data-test={testId}>
       {text}
     </Button>
   );

--- a/apps/web/src/components/common/CustomTextFieldProps.tsx
+++ b/apps/web/src/components/common/CustomTextFieldProps.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, ChangeEvent } from "react";
 import {
   FormControl,
   InputLabel,
@@ -17,7 +17,9 @@ interface CustomTextFieldProps {
   required?: boolean;
   placeholder?: string;
   value?: string;
-  handleChange?: any;
+  onChange?: (e: ChangeEvent<HTMLInputElement>) => void;
+  testId?: string;
+  autoFocus?: boolean;
 }
 
 const CustomTextField: React.FC<CustomTextFieldProps> = ({
@@ -27,41 +29,45 @@ const CustomTextField: React.FC<CustomTextFieldProps> = ({
   helperText,
   required = false,
   placeholder,
-  handleChange,
+  onChange,
   value,
+  testId,
 }) => {
   const [showPassword, setShowPassword] = useState(false);
 
-  const handleTogglePassword = () => {
-    setShowPassword(!showPassword);
-  };
-
-  const isPasswordType = type === "password";
+  const isPassword = type === "password";
+  const inputType = isPassword && showPassword ? "text" : type;
 
   return (
-    <FormControl
-      sx={{ width: "100%", my: 2 }}
-      required={required}
-      variant="filled">
-      <InputLabel required={false}>{label}</InputLabel>
+    <FormControl sx={{ width: 1, my: 2 }} variant="filled">
+      <InputLabel>{label}</InputLabel>
       <FilledInput
-        type={isPasswordType && showPassword ? "text" : type}
+        type={inputType}
         name={name}
         placeholder={placeholder}
         value={value}
-        onChange={handleChange}
+        onChange={onChange}
         endAdornment={
-          isPasswordType && (
+          isPassword && (
             <InputAdornment position="end">
-              <IconButton onClick={handleTogglePassword} edge="end">
+              <IconButton
+                onClick={() => setShowPassword(show => !show)}
+                edge="end"
+                data-test="toggle-password-visibility"
+                tabIndex={-1}
+                aria-label="toggle password visibility">
                 {showPassword ? <VisibilityOff /> : <Visibility />}
               </IconButton>
             </InputAdornment>
           )
         }
+        data-test={testId}
+        // Do NOT add required here
       />
-      {helperText && (
-        <FormHelperText sx={{ fontSize: "12px", color: "red" }}>
+      {helperText?.trim() && (
+        <FormHelperText
+          sx={{ fontSize: 12, color: "red" }}
+          data-test="error-helper-text">
           {helperText}
         </FormHelperText>
       )}

--- a/package.json
+++ b/package.json
@@ -14,11 +14,13 @@
     "native:android": "yarn workspace native android",
     "native:ios": "yarn workspace ios",
     "user:build": "yarn workspace user build",
-    "user:dev": "yarn workspace user dev",
-    "user:debug": "yarn workspace user debug",
-    "user:prod": "yarn workspace user prod",
+    "user:dev": "yarn workspace user start:dev",
+    "user:debug": "yarn workspace user start:debug",
+    "user:prod": "yarn workspace user start:prod",
     "pre-commit": "yarn workspaces run lint-staged",
     "cypress-component-test": "yarn workspace web run cy:component",
+    "cypress-e2e-test": "yarn workspace web cy:e2e",
+    "cypress-e2e-headless-test": "yarn workspace web cy:e2e-headless",
     "commitlint": "commitlint",
     "lint-staged": "lint-staged",
     "prettier": "prettier --write .",
@@ -35,7 +37,8 @@
       "**/react",
       "**/react-dom",
       "!apps/web/react",
-      "!apps/web/react-dom"
+      "!apps/web/react-dom",
+      "**/expo-constants"
     ]
   },
   "devDependencies": {


### PR DESCRIPTION
- Add auth guards in public and protected layout folders
- Move header and bottom navigation to protected layout component
- Refactor `CustomSubmitButton` and `CustomTextField`
- Add base URL and custom `getByData` command for `data-test` selectors in cypress
- Implement E2E tests for login and signup flows
- Add `data-test="home-page-element"` to home page
- Fix issues in root `package.json`
- Add Cypress E2E script to `package.json` in web workspace
- Install `start-server-and-test` as a dev dependency in web workspace

resolves  #454 
