### PR TITLE
feat(web): add discard-confirmation dialog to WalletCreateDrawer

### DIFF
--- a/apps/web/cypress/component/WalletCreateDrawer.cy.tsx
+++ b/apps/web/cypress/component/WalletCreateDrawer.cy.tsx
@@ -1,0 +1,107 @@
+import React from "react";
+import WalletCreateDrawer from "../../src/components/WalletCreateDrawer";
+
+describe("WalletCreateDrawer Component", () => {
+  const mountDrawer = (
+    props: Partial<React.ComponentProps<typeof WalletCreateDrawer>> = {},
+  ) => {
+    const onClose = cy.spy().as("onClose");
+    const onCreate = cy.spy().as("onCreate");
+    const defaultProps = {
+      open: true,
+      onClose,
+      onCreate,
+      existingNames: [] as string[],
+    };
+    cy.mount(<WalletCreateDrawer {...defaultProps} {...props} />);
+    return { onClose, onCreate };
+  };
+
+  const getNameInput = () => cy.get('input[name="name"]');
+  const getDescInput = () => cy.get('input[name="description"]');
+  const getCreateBtn = () => cy.contains("button", "Create Wallet");
+  const getCloseBtn = () => cy.get('button[aria-label="close"]');
+  const getErrorHelper = () => cy.get('[data-test="error-helper-text"]');
+
+  it("renders when open and closes immediately when clean (no confirm)", () => {
+    const { onClose } = mountDrawer({ open: true });
+
+    cy.contains("Provide wallet details").should("exist");
+
+    getCloseBtn().click();
+    cy.get("@onClose").should("have.been.calledOnce");
+  });
+
+  it("does not render when open = false", () => {
+    cy.mount(
+      <WalletCreateDrawer
+        open={false}
+        onClose={cy.spy().as("onClose")}
+        onCreate={cy.spy().as("onCreate")}
+        existingNames={[]}
+      />,
+    );
+    cy.contains("Provide wallet details").should("not.exist");
+  });
+
+  it('disables "Create Wallet" when name is empty/whitespace; enables when valid', () => {
+    mountDrawer();
+
+    getCreateBtn().should("be.disabled");
+
+    getNameInput().type("   ");
+    getCreateBtn().should("be.disabled");
+
+    getNameInput().clear().type("My Wallet");
+    getCreateBtn().should("not.be.disabled");
+  });
+
+  it("calls onCreate with trimmed payload, then calls onClose", () => {
+    const { onCreate, onClose } = mountDrawer();
+
+    getNameInput().type("  My Wallet  ");
+    getDescInput().type("  A test description  ");
+
+    getCreateBtn().click();
+
+    cy.get("@onCreate").should("have.been.calledOnce");
+    cy.get("@onCreate")
+      .its("firstCall.args.0")
+      .should((payload: any) => {
+        expect(payload).to.deep.equal({
+          name: "My Wallet",
+          description: "A test description",
+        });
+      });
+
+    cy.get("@onClose").should("have.been.calledOnce");
+  });
+
+  it("shows duplicate helper text and disables Create when name exists (case-insensitive)", () => {
+    mountDrawer({ existingNames: ["My Wallet"] });
+
+    getNameInput().type("my wallet");
+    getErrorHelper().should("contain.text", "Wallet name should be unique.");
+    getCreateBtn().should("be.disabled");
+  });
+
+  it("dirty close shows confirm dialog; KEEP leaves open; DISCARD triggers onClose", () => {
+    const { onClose } = mountDrawer();
+
+    getNameInput().type("Temp");
+
+    getCloseBtn().click();
+    cy.contains("Discard changes?").should("be.visible");
+    cy.contains("Are you sure you want to discard the new wallet?").should(
+      "be.visible",
+    );
+
+    cy.contains("button", "KEEP CHANGES").click();
+    cy.contains("Provide wallet details").should("exist");
+    cy.get("@onClose").should("not.have.been.called");
+
+    getCloseBtn().click();
+    cy.contains("button", "DISCARD").click();
+    cy.get("@onClose").should("have.been.calledOnce");
+  });
+});

--- a/apps/web/src/components/WalletCreateDrawer.tsx
+++ b/apps/web/src/components/WalletCreateDrawer.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import React, { useEffect, useMemo, useState, ChangeEvent } from "react";
+import React, {
+  useEffect,
+  useMemo,
+  useState,
+  ChangeEvent,
+  useCallback,
+} from "react";
 import {
   Box,
   Drawer,
@@ -8,6 +14,10 @@ import {
   Typography,
   Button,
   Divider,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
 } from "@mui/material";
 import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
 import CustomTextField from "@/components/common/CustomTextField";
@@ -27,11 +37,15 @@ const WalletCreateDrawer: React.FC<WalletCreateDrawerProps> = ({
 }) => {
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  const isDirty = Boolean(name.trim() || description.trim());
 
   useEffect(() => {
     if (!open) {
       setName("");
       setDescription("");
+      setConfirmOpen(false);
     }
   }, [open]);
 
@@ -49,74 +63,123 @@ const WalletCreateDrawer: React.FC<WalletCreateDrawerProps> = ({
     onClose();
   };
 
+  const handleCloseRequest = useCallback(() => {
+    if (isDirty) {
+      setConfirmOpen(true);
+    } else {
+      onClose();
+    }
+  }, [isDirty, onClose]);
+
+  const handleKeep = () => setConfirmOpen(false);
+
+  const handleDiscard = () => {
+    setName("");
+    setDescription("");
+    setConfirmOpen(false);
+    onClose();
+  };
+
   return (
-    <Drawer
-      anchor="bottom"
-      open={open}
-      onClose={onClose}
-      PaperProps={{
-        sx: {
-          borderTopLeftRadius: 3,
-          borderTopRightRadius: 3,
-          pb: 2,
-          maxWidth: 560,
-          mx: "auto",
-          width: "100%",
-        },
-      }}>
-      <Box sx={{ p: 2.5, pb: 1.5, display: "flex", alignItems: "center" }}>
-        <Typography
-          variant="h6"
-          sx={{ fontWeight: 600, flex: 1, letterSpacing: 0.2 }}>
-          Provide wallet details
-        </Typography>
-        <IconButton aria-label="close" onClick={onClose}>
-          <CloseRoundedIcon />
-        </IconButton>
-      </Box>
-      <Divider />
+    <>
+      <Drawer
+        anchor="bottom"
+        open={open}
+        onClose={handleCloseRequest}
+        aria-labelledby="wallet-create-drawer-title"
+        PaperProps={{
+          sx: {
+            borderTopLeftRadius: 3,
+            borderTopRightRadius: 3,
+            pb: 2,
+            maxWidth: 560,
+            mx: "auto",
+            width: "100%",
+          },
+        }}>
+        <Box sx={{ p: 2.5, pb: 1.5, display: "flex", alignItems: "center" }}>
+          <Typography
+            id="wallet-create-drawer-title"
+            variant="h6"
+            sx={{ fontWeight: 600, flex: 1, letterSpacing: 0.2 }}>
+            Provide wallet details
+          </Typography>
+          <IconButton aria-label="close" onClick={handleCloseRequest}>
+            <CloseRoundedIcon />
+          </IconButton>
+        </Box>
+        <Divider />
 
-      <Box sx={{ p: 2.5 }}>
-        <CustomTextField
-          label="Name"
-          name="name"
-          placeholder="Name"
-          value={name}
-          onChange={(e: ChangeEvent<HTMLInputElement>) =>
-            setName(e.target.value)
-          }
-          testId="wallet-name-input"
-          error={Boolean(name.trim() && isDuplicate)}
-          helperText={isDuplicate ? "Wallet name should be unique." : undefined}
-        />
+        <Box sx={{ p: 2.5 }}>
+          <CustomTextField
+            label="Name"
+            name="name"
+            placeholder="Name"
+            value={name}
+            onChange={(e: ChangeEvent<HTMLInputElement>) =>
+              setName(e.target.value)
+            }
+            testId="wallet-name-input"
+            error={Boolean(name.trim() && isDuplicate)}
+            helperText={
+              isDuplicate ? "Wallet name should be unique." : undefined
+            }
+          />
 
-        <CustomTextField
-          label="Description"
-          name="description"
-          placeholder="This text will be visible when you share your wallet."
-          value={description}
-          onChange={(e: ChangeEvent<HTMLInputElement>) =>
-            setDescription(e.target.value)
-          }
-          testId="wallet-description-input"
-        />
+          <CustomTextField
+            label="Description"
+            name="description"
+            placeholder="This text will be visible when you share your wallet."
+            value={description}
+            onChange={(e: ChangeEvent<HTMLInputElement>) =>
+              setDescription(e.target.value)
+            }
+            testId="wallet-description-input"
+          />
 
-        <Button
-          fullWidth
-          size="large"
-          variant="contained"
-          disabled={!name.trim() || isDuplicate}
-          onClick={handleCreate}
-          data-test="wallet-create-submit"
-          sx={{
-            mt: 1.5,
-            ":disabled": { backgroundColor: "#E0E0E0", color: "#9E9E9E" },
-            textTransform: "uppercase",
-          }}>
-          Create Wallet
-        </Button>
-      </Box>
-    </Drawer>
+          <Button
+            data-test="wallet-create-submit"
+            fullWidth
+            size="large"
+            variant="contained"
+            disabled={!name.trim() || isDuplicate}
+            onClick={handleCreate}
+            sx={{
+              mt: 1.5,
+              ":disabled": { backgroundColor: "#E0E0E0", color: "#9E9E9E" },
+              textTransform: "uppercase",
+            }}>
+            Create Wallet
+          </Button>
+        </Box>
+      </Drawer>
+
+      <Dialog
+        open={confirmOpen}
+        onClose={handleKeep}
+        aria-labelledby="discard-dialog-title">
+        <DialogTitle id="discard-dialog-title" sx={{ fontWeight: 600 }}>
+          Discard changes?
+        </DialogTitle>
+        <DialogContent sx={{ pt: 1, pb: 0 }}>
+          <Typography variant="body1">
+            Are you sure you want to discard the new wallet?
+          </Typography>
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 2 }}>
+          <Button onClick={handleKeep} variant="text" sx={{ fontWeight: 600 }}>
+            KEEP CHANGES
+          </Button>
+          <Button
+            onClick={handleDiscard}
+            variant="outlined"
+            color="error"
+            sx={{ fontWeight: 600 }}>
+            DISCARD
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
   );
 };
 


### PR DESCRIPTION
<!--

name: "Monorepo Contribution" about: "Template for contributions in a monorepo
with apps and packages folders" title: "[Feature/Bug] - Title" labels:
["contribution"] assignees: "" # Leave blank if no specific assignee

---

-->

# Description

Add confirmation dialog for discarding new wallet form changes

Fixes: #364 
or  
Resolves: # (issue number)

---

## Changes Made

- [ ] Changes in **`apps`** folder (specify the app and briefly describe the
      changes):
  - [x] `Web`
  - [ ] `Native`

- [ ] Changes in **`packages`** folder (specify the package and briefly describe
      the changes):
  - [ ] `Core`

---

### Type of Change

- [ ] 🐛 **Bug fix** (non-breaking change which fixes an issue)
- [x] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 💥 **Breaking change** (fix or feature that would cause existing
      functionality to not work as expected)
- [ ] 📝 **Documentation update** (changes)

---

#### Screenshots

|       Before        |       After        |
| :-----------------: | :----------------: |
| "screenshot before" | "screenshot after" |
<img width="1062" height="614" alt="Screen Shot 2025-10-12 at 2 05 40 PM" src="https://github.com/user-attachments/assets/6f11b76c-223b-46c8-868e-21b2717d497e" />

---

### How Has This Been Tested?

- [] Cypress integration
- [x] Cypress component tests
- [ ] Jest unit tests

---

### Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

---

### Additional Comments

_(Optional) Add any additional comments or notes for reviewers here._
