### PR TITLE
ci: replace deprecated --frozen-lockfile with --immutable in workflows

### DIFF
--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -23,7 +23,7 @@ jobs:
         run: corepack enable
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: yarn install --immutable
 
       - name: Run Prettier Check
         run: yarn format --check .

--- a/.github/workflows/static-website-deploy-dev.yml
+++ b/.github/workflows/static-website-deploy-dev.yml
@@ -38,7 +38,7 @@ jobs:
           cache: "yarn"
 
       - name: Install Dependencies
-        run: yarn install --frozen-lockfile
+        run: yarn install --immutable
 
       - name: Set Environment Variables for Build
         run: |


### PR DESCRIPTION
# Description

Replaced the deprecated `--frozen-lockfile` flag with the modern `--immutable` flag in GitHub Actions workflows.  This ensures compatibility with Yarn 4+ and prevents future installation issues.

Fixes: #585

---

## Changes Made

- [x] Changes in **`.github/workflows`** folder:
  - Updated `lint-format.yml` to use `yarn install --immutable`
  - Updated `static-website-deploy-dev.yml` to use `yarn install --immutable`
- [ ] Changes in **`apps`** folder:
  - [ ] `Web`
  - [ ] `Native`

- [ ] Changes in **`packages`** folder:
  - [ ] `Core`

---

### Type of Change

- [x] 🐛 **Bug fix** (non-breaking change which fixes an issue)

---

#### Screenshots

|       Before        |       After        |
| :-----------------: | :----------------: |
| N/A (workflow only) | N/A (workflow only) |

---

### How Has This Been Tested?

- [x] Verified `yarn install --immutable` runs successfully locally
- [x] Confirmed no changes to `yarn.lock` were required
- [x] CI will validate workflows on PR

---

### Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

---

### Additional Comments

This is a small CI-only fix. No application code or dependencies were modified.