### PR TITLE
ci: disable Husky during semantic-release to fix workspace lockfile e…

### DIFF
--- a/.github/workflows/build-dev-docker-img-and-relase.yml
+++ b/.github/workflows/build-dev-docker-img-and-relase.yml
@@ -46,6 +46,16 @@ jobs:
             @semantic-release/github
 
       - name: Run semantic-release
-        run: semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HUSKY: 0
+        run: |
+          yarn dlx \
+            -p semantic-release@latest \
+            -p @semantic-release/commit-analyzer@latest \
+            -p @semantic-release/release-notes-generator@latest \
+            -p @semantic-release/changelog@latest \
+            -p @semantic-release/npm@latest \
+            -p @semantic-release/git@latest \
+            -p @semantic-release/github@latest \
+            semantic-release


### PR DESCRIPTION
<!--
name: "Monorepo Contribution"
about: "Template for contributions in a monorepo with apps and packages folders"
title: "[CI] - Semantic Release configuration update"
labels: ["contribution", "devops"]
assignees: ""
-->

# Description

Follow up fix on PR #574 for testing CI on main for a failing Service CI/CD Pipeline to Release (wallet-app) / Release (push) test. 

Fixes: #508 (Add semantic-release to wallet app)

---

## Changes Made

-   **Workflow Updates**
    
    -   `.github/workflows/build-dev-docker-img-and-relase.yml`
        -   Replaced global `npm i -g semantic-release` installation with a `yarn dlx` command for isolated, version-consistent plugin execution.
        - Added environment variable `HUSKY: 0` to disable pre-commit hooks during the release process, fixing the lockfile error:
`Internal Error: treetracker-wallet-app@workspace:. not present in your lockfile.`
        - Ensures semantic-release runs cleanly in CI without interference from Husky or lint-staged, fully automating version bumps and changelog generation.

---

### Type of Change

- [x] 🧩 **CI/CD improvement** (enhancement to automation workflows)
- [ ] 🐛 **Bug fix**
- [ ] ✨ **New feature**
- [ ] 💥 **Breaking change**
- [ ] 📝 **Documentation update**

---

### How Has This Been Tested?

- [x] Local dry-run test executed:
 
```bash
corepack enable
yarn install --immutable

# semantic-release requires a GitHub token, so use a dummy one for testing
$env:GITHUB_TOKEN = "test"

yarn dlx `
  -p semantic-release@latest `
  -p @semantic-release/commit-analyzer@latest `
  -p @semantic-release/release-notes-generator@latest `
  -p @semantic-release/changelog@latest `
  -p @semantic-release/npm@latest `
  -p @semantic-release/git@latest `
  -p @semantic-release/github@latest `
  semantic-release --dry-run --branches main

Remove-Item Env:GITHUB_TOKEN
```

✅ Verified results:

-   All plugins loaded successfully
-   No missing dependencies
-   Semantic-release correctly detects branch configuration
-   No version tags or changelog commits generated in dry-run mode

---

## Summary

This PR fixes the semantic-release lockfile error:

`Internal Error: treetracker-wallet-app@workspace:. not present in your lockfile.`

which occurred during the transition from a folder-specific release configuration to a unified monorepo release process. The update ensures semantic-release runs reliably across the entire repository.

---