### PR TITLE
ci(workflow): add ci-cd-pr-user-wallet.yml

### DIFF
--- a/.github/workflows/ci-cd-pr-user-wallet.yml
+++ b/.github/workflows/ci-cd-pr-user-wallet.yml
@@ -1,0 +1,47 @@
+# This workflow triggers on pull requests that modify non-Markdown files in the User module (apps/user/**).
+# It runs e2e, integration and unit tests to validate those changes.
+
+name: PR CI for User module
+
+on:
+  pull_request:
+    paths:
+      - apps/user/**
+      - "!apps/user/**/*.md"
+  workflow_dispatch:
+
+jobs:
+  unit-integration-e2e-tests:
+    runs-on: ubuntu-latest
+    env:
+      NODE_TLS_REJECT_UNAUTHORIZED: 0
+      PRIVATE_KEYCLOAK_REALM: ${{ secrets.PRIVATE_KEYCLOAK_REALM }}
+      PRIVATE_KEYCLOAK_BASE_URL: ${{ secrets.PRIVATE_KEYCLOAK_BASE_URL }}
+      PRIVATE_KEYCLOAK_CLIENT_SECRET: ${{ secrets.PRIVATE_KEYCLOAK_CLIENT_SECRET }}
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      PRIVATE_KEYCLOAK_CLIENT_ID: ${{ secrets.PRIVATE_KEYCLOAK_CLIENT_ID }}
+      PRIVATE_WALLET_API_KEY: ${{ secrets.PRIVATE_WALLET_API_KEY }}
+      CORS_ORIGINS_DEV: ${{ vars.CORS_ORIGINS_DEV }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20.x"
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Run Unit Tests
+        run: yarn user:test:unit
+
+      - name: Run Integration Tests
+        run: yarn user:test:int
+
+      - name: Run User Service E2E Tests
+        run: yarn user:test:e2e --forceExit


### PR DESCRIPTION
<!--

name: "Monorepo Contribution" about: "Template for contributions in a monorepo
with apps and packages folders" title: "[Feature/Bug] - Title" labels:
["contribution"] assignees: "" # Leave blank if no specific assignee

---

-->

# Description

Following the [README.md](https://github.com/Greenstand/treetracker-wallet-app/blob/main/apps/user/README.md), adds a CI workflow that runs unit, integration, and end-to-end tests (`user:test:unit`, `user:test:int`, `user:test:e2e`) for the User module when a pull request modifies non-Markdown files in `apps/user/**` 

Resolves: # [(606)](https://github.com/Greenstand/treetracker-wallet-app/issues/606)

---

## Changes Made

- [ ] Changes in **`apps`** folder (specify the app and briefly describe the
      changes):
  - [ ] `Web`
  - [ ] `Native`
  - [x] None

- [ ] Changes in **`packages`** folder (specify the package and briefly describe
      the changes):
  - [ ] `Core`
  - [x] None

---

### Type of Change

- [ ] 🐛 **Bug fix** (non-breaking change which fixes an issue)
- [x] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 💥 **Breaking change** (fix or feature that would cause existing
      functionality to not work as expected)
- [ ] 📝 **Documentation update** (changes)

---

#### Screenshots
The workflow has been verified in a forked repo.
<img width="2274" height="928" alt="image" src="https://github.com/user-attachments/assets/22fd5822-e08f-4026-bbd2-ce8bfab6e4f0" />

---

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

---

### Additional Comments

Environment variables and secrets required by this workflow are already configured in the upstream repository.