### PR TITLE
ci(workflow): add ci-cd-pr-bdd-wallet.yml

### DIFF
--- a/.github/workflows/ci-cd-pr-bdd-wallet.yml
+++ b/.github/workflows/ci-cd-pr-bdd-wallet.yml
@@ -1,0 +1,64 @@
+# This workflow is triggered on every pull request,
+# excluding changes to those files with the extensions .md, .yaml, and .yml
+
+name: PR CI BDD e2e tests
+
+on:
+  pull_request:
+    paths-ignore:
+      - "**/*.md"
+      - "**/*.yml"
+      - "**/*.yaml"
+  workflow_dispatch:
+
+jobs:
+  full-bdd-e2e-tests:
+    runs-on: ubuntu-latest
+    env:
+      NODE_TLS_REJECT_UNAUTHORIZED: "0"
+      NEXT_PUBLIC_WALLET_APP_API: ${{ vars.NEXT_PUBLIC_WALLET_APP_API }}
+      NEXT_PUBLIC_ENV: ${{ vars.NEXT_PUBLIC_ENV }}
+      NEXT_PUBLIC_API_TIMEOUT: ${{ vars.NEXT_PUBLIC_API_TIMEOUT }}
+      NEXT_PUBLIC_API_RETRIES: ${{ vars.NEXT_PUBLIC_API_RETRIES }}
+      NEXT_PUBLIC_BASE_URL: ${{ vars.NEXT_PUBLIC_BASE_URL }}
+      CORS_ORIGINS_DEV: ${{ vars.CORS_ORIGINS_DEV }}
+      PRIVATE_KEYCLOAK_REALM: ${{ secrets.PRIVATE_KEYCLOAK_REALM }}
+      PRIVATE_KEYCLOAK_BASE_URL: ${{ secrets.PRIVATE_KEYCLOAK_BASE_URL }}
+      PRIVATE_KEYCLOAK_CLIENT_SECRET: ${{ secrets.PRIVATE_KEYCLOAK_CLIENT_SECRET }}
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      PRIVATE_KEYCLOAK_CLIENT_ID: ${{ secrets.PRIVATE_KEYCLOAK_CLIENT_ID }}
+      PRIVATE_WALLET_API_KEY: ${{ secrets.PRIVATE_WALLET_API_KEY }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20.x"
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Install latest Chrome binary
+        run: |
+          wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
+          sudo sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list'
+          sudo apt update
+          sudo apt install google-chrome-stable
+
+      - name: Add a Chrome driver
+        run: CHROMEDRIVER_VERSION=LATEST yarn add chromedriver
+
+      - name: Start user service in the background
+        run: |
+          yarn user:dev &>/dev/null & npx wait-on tcp:8080 --timeout 30000
+          yarn web:dev &>/dev/null & npx wait-on tcp:3000 --timeout 30000
+
+      - name: Run full bdd test
+        uses: cypress-io/github-action@v6
+        with:
+          command: yarn bdd:e2e


### PR DESCRIPTION
<!--

name: "Monorepo Contribution" about: "Template for contributions in a monorepo
with apps and packages folders" title: "[Feature/Bug] - Title" labels:
["contribution"] assignees: "" # Leave blank if no specific assignee

---

-->

# Description

Following [README.md](https://github.com/Greenstand/treetracker-wallet-app/blob/main/README.md), adds a workflow that can be triggered on every pull request, excluding changes to those files with the extensions `.md`, `.yaml`, and `.yml`

Resolves: #[510](https://github.com/Greenstand/treetracker-wallet-app/issues/510)

---

## Changes Made

- [ ] Changes in **`apps`** folder (specify the app and briefly describe the
      changes):
  - [ ] `Web`
  - [ ] `Native`
  - [x]  None

- [ ] Changes in **`packages`** folder (specify the package and briefly describe
      the changes):
  - [ ] `Core`
  - [x]  None

---

### Type of Change

- [ ] 🐛 **Bug fix** (non-breaking change which fixes an issue)
- [x] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 💥 **Breaking change** (fix or feature that would cause existing
      functionality to not work as expected)
- [ ] 📝 **Documentation update** (changes)

---

#### Screenshots
The workflow has been verified in a forked repo.

<img width="1165" height="514" alt="image" src="https://github.com/user-attachments/assets/d12db5f9-4af1-4d90-817b-56fcf6d6affb" />



---

### How Has This Been Tested?

- [ ] Cypress integration
- [ ] Cypress component tests
- [ ] Jest unit tests

---

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

---

### Additional Comments

Environment variables and secrets required by this workflow are already configured in the upstream repository.