### PR TITLE
ci(workflow): add ci-cd-pr-wallet-package-wallet.yml

### DIFF
--- a/.github/workflows/ci-cd-pr-wallet-package-wallet.yml
+++ b/.github/workflows/ci-cd-pr-wallet-package-wallet.yml
@@ -1,10 +1,15 @@
-# This workflow triggers on pull requests that modify files (other than *.md) in the wallet package (i.e., package/wallet/**)
+# This workflow triggers on pull requests that modify files (other than *.md) in the wallet package (i.e., packages/wallet/**)
 # It runs e2e tests to validate changes.
 
 name: PR CI for Wallet Package
 
 on:
-  pull_request:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - edited
     paths:
       - "packages/wallet/**"
       - "!**/*.md"
@@ -22,6 +27,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Use Node.js 20.x
         uses: actions/setup-node@v4


### PR DESCRIPTION
<!--

name: "Monorepo Contribution" about: "Template for contributions in a monorepo
with apps and packages folders" title: "[Feature/Bug] - Title" labels:
["contribution"] assignees: "" # Leave blank if no specific assignee

---

-->

# Description

Following the [README.md](https://github.com/Greenstand/treetracker-wallet-app/blob/main/packages/wallet/README.md), this workflow triggers on pull requests that modify files (other than *.md) in the wallet package (i.e., `package/wallet/**`)
It runs e2e tests to validate changes.

Resolves: #579 

---

## Changes Made

- [ ] Changes in **`apps`** folder (specify the app and briefly describe the
      changes):
  - [ ] `Web`
  - [ ] `Native`
  - [x]  None

- [ ] Changes in **`packages`** folder (specify the package and briefly describe
      the changes):
  - [ ] `Core`
  - [x]  None

---

### Type of Change

- [ ] 🐛 **Bug fix** (non-breaking change which fixes an issue)
- [x] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 💥 **Breaking change** (fix or feature that would cause existing
      functionality to not work as expected)
- [ ] 📝 **Documentation update** (changes)

---

#### Screenshots
The workflow has been verified in a forked repo
<img width="1989" height="955" alt="image" src="https://github.com/user-attachments/assets/a2d97a4a-9527-4168-bcac-3e0746aac129" />


---

### How Has This Been Tested?

- [ ] Cypress integration
- [ ] Cypress component tests
- [ ] Jest unit tests

---

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

---

### Additional Comments

Environment variables and secrets required by this workflow are already configured in the upstream repository.