### PR TITLE
Add multi-environment CI workflow with version selection

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,4 +1,4 @@
-name: Deploy to AWS
+name: Deploy Wallet App on AWS
 
 on:
   workflow_dispatch:
@@ -18,7 +18,6 @@ on:
 
 env:
   PROJECT_DIRECTORY: ./apps/web
-  REPOSITORY: 'Greenstand/treetracker-wallet-app'
   NODE_VERSION: "20.x"
   ENVIRONMENT: ${{ inputs.environment }} 
   DEV_URL: https://wallet-dev.treetracker.org
@@ -90,7 +89,7 @@ jobs:
     name: Deploy to AWS
     runs-on: ubuntu-latest
     needs: [build]
-    if: github.repository == ${{ env.REPOSITORY }}
+    if: github.repository == 'Greenstand/treetracker-wallet-app'
     steps:
       - name: Download Build Artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
<!--

name: "Monorepo Contribution"
about: "Template for contributions in a monorepo with apps and packages folders"
title: "[Feature/Bug] - Title"
labels: ["contribution"]
assignees: "" # Leave blank if no specific assignee

-->


# Description

Added a CI workflow to deploy the TreeTracker Wallet App to multiple environments (development, testing, and production) with manual version selection for the workflow. This includes:  

- Environment-specific deployment steps
- Conditional execution based on repository
- Workflow variables for maintainable expressions

Fixes: #449 

---

## Changes Made

  - Added **CI workflow** for deployment:
  - Deploy to **dev**, **test**, and **prod** environments
  - Manual workflow input to select **version**

---

### Type of Change

- [x] ✨ **New feature** (non-breaking change which adds functionality)

---

### How Has This Been Tested?

- [x] Manual run of GitHub Actions workflow for dev/test/prod

---

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

---

### Additional Comments

This update introduces a flexible CI/CD workflow that allows manual version selection and environment-specific deployments, making deployments safer and more maintainable.
