### PR TITLE
fix(native): add header to settings tab

### DIFF
--- a/apps/native/app/(tabs)/settings/_layout.tsx
+++ b/apps/native/app/(tabs)/settings/_layout.tsx
@@ -1,5 +1,16 @@
 import { Stack } from "expo-router";
+import HeaderSearch from "@/components/HeaderSearch";
 
 export default function SettingsLayout() {
-  return <Stack screenOptions={{ headerShown: false }} />;
+  return (
+    <Stack screenOptions={{ headerShown: false }}>
+      <Stack.Screen
+        name="index"
+        options={{
+          headerShown: true,
+          header: () => <HeaderSearch />,
+        }}
+      />
+    </Stack>
+  );
 }

--- a/apps/native/app/(tabs)/settings/index.tsx
+++ b/apps/native/app/(tabs)/settings/index.tsx
@@ -10,6 +10,7 @@ import {
 } from "react-native";
 import { MaterialIcons } from "@expo/vector-icons";
 import { Colors } from "@/constants/Colors";
+import HeaderSearch from "@/components/HeaderSearch";
 
 type SettingsItemType = {
   id: string;
@@ -81,7 +82,8 @@ const SettingsItem = ({
       onPress={onPress}
       android_ripple={{ color: "#e0e0e0" }}
       accessibilityRole="button"
-      accessibilityLabel={`${item.title}${item.subtitle ? `, ${item.subtitle}` : ""}`}>
+      accessibilityLabel={`${item.title}${item.subtitle ? `, ${item.subtitle}` : ""}`}
+    >
       <View style={styles.itemLeftSection}>
         <View style={styles.iconContainer}>
           <MaterialIcons name={item.icon} size={24} color="#666" />
@@ -111,14 +113,6 @@ export default function Settings() {
 
   return (
     <SafeAreaView style={styles.safeArea}>
-      {/* Header - commented out because header should not be implemented but ready to be added back or replaced.
-      <View style={styles.header}>
-        <Ionicons name="arrow-back" size={24} color="#666" />
-        <Text style={styles.headerTitle}>Settings</Text>
-        <Ionicons name="settings-outline" size={24} color="#666" />
-      </View>
-      */}
-
       <ScrollView style={styles.scrollContainer}>
         {/* Settings Title */}
         <Text style={styles.settingsTitle}>Settings</Text>
@@ -143,7 +137,8 @@ export default function Settings() {
           <Pressable
             onPress={handleLogout}
             accessibilityRole="button"
-            accessibilityLabel="Log out">
+            accessibilityLabel="Log out"
+          >
             <Text style={styles.logoutText}>LOG OUT</Text>
           </Pressable>
         </View>
@@ -157,20 +152,6 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: "#f5f5f5",
   },
-  // Header styles
-  // header: {
-  //   flexDirection: "row",
-  //   justifyContent: "space-between",
-  //   alignItems: "center",
-  //   paddingHorizontal: 16,
-  //   paddingVertical: 12,
-  //   backgroundColor: "#f5f5f5",
-  // },
-  // headerTitle: {
-  //   fontSize: 18,
-  //   fontWeight: "600",
-  //   color: "#333",
-  // },
   scrollContainer: {
     flex: 1,
     paddingHorizontal: 16,


### PR DESCRIPTION
# Description
fixes #697 

This is an offshoot change from this [PR](https://github.com/Greenstand/treetracker-wallet-app/pull/698). From the figma design, it seems that the header we want to use is more similar to the one used in the Home screen so I took the liberty to use the existing `HeaderSearch` component instead. 

---

## Changes Made

- [ ] Changes in **`apps`** folder (specify the app and briefly describe the
      changes):
  - [ ] `Web`
  - [X] `Native`

- [ ] Changes in **`packages`** folder (specify the package and briefly describe
      the changes):
  - [ ] `Core`

---

### Type of Change

- [ ] 🐛 **Bug fix** (non-breaking change which fixes an issue)
- [X] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 💥 **Breaking change** (fix or feature that would cause existing
      functionality to not work as expected)
- [ ] 📝 **Documentation update** (changes)

---

#### Screenshots

Expo browser

<img width="502" height="798" alt="Screenshot 2026-03-22 at 10 01 30 AM" src="https://github.com/user-attachments/assets/d9c092a7-64b7-491d-86a9-628974e15a4b" />

Android and IOS Emulator (Pixel9, Iphone 17 Pro)
<img width="1017" height="945" alt="Screenshot 2026-03-22 at 10 03 35 AM" src="https://github.com/user-attachments/assets/771ef2be-ba44-47c2-9dc8-85a03c0f2d94" />

---

### How Has This Been Tested?

- [x] Manual Testing

---

### Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

