### PR TITLE
fix(user): improve login and register error handling

### DIFF
--- a/apps/user/libs/validation/dtos/register-user.dto.ts
+++ b/apps/user/libs/validation/dtos/register-user.dto.ts
@@ -1,16 +1,22 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { IsNotEmpty, IsString } from "class-validator";
+import {
+  IsEmail,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  MinLength,
+} from "class-validator";
 
 export class RegisterUserDto {
-  @ApiProperty()
+  @ApiProperty({ required: false })
+  @IsOptional()
   @IsString()
-  @IsNotEmpty()
-  firstName: string;
+  firstName?: string;
 
-  @ApiProperty()
+  @ApiProperty({ required: false })
+  @IsOptional()
   @IsString()
-  @IsNotEmpty()
-  lastName: string;
+  lastName?: string;
 
   @ApiProperty()
   @IsString()
@@ -18,26 +24,27 @@ export class RegisterUserDto {
   username: string;
 
   @ApiProperty()
-  @IsString()
+  @IsEmail()
   @IsNotEmpty()
   email: string;
 
   @ApiProperty()
   @IsString()
   @IsNotEmpty()
+  @MinLength(8)
   password: string;
 
   constructor(
-    firstName: string,
-    lastName: string,
     username: string,
     email: string,
     password: string,
+    firstName?: string,
+    lastName?: string,
   ) {
-    this.firstName = firstName;
-    this.lastName = lastName;
     this.username = username;
     this.email = email;
     this.password = password;
+    this.firstName = firstName;
+    this.lastName = lastName;
   }
 }

--- a/apps/user/src/auth/auth.service.ts
+++ b/apps/user/src/auth/auth.service.ts
@@ -1,5 +1,5 @@
 import { HttpService } from "@nestjs/axios";
-import { HttpException, Injectable, Logger } from "@nestjs/common";
+import { HttpException, HttpStatus, Injectable, Logger } from "@nestjs/common";
 import { firstValueFrom } from "rxjs";
 
 type KeycloakResponse = {
@@ -41,18 +41,19 @@ export class AuthService {
       );
 
       this.bearerToken = response?.data?.access_token;
-      this.tokenExpiresAt = Date.now() * response?.data?.expires_in * 1000;
+      this.tokenExpiresAt = Date.now() + response?.data?.expires_in * 1000;
 
       return response?.data?.access_token;
     } catch (e) {
+      const status = e.response?.status || HttpStatus.SERVICE_UNAVAILABLE;
+      const description =
+        e.response?.data?.error_description || e.message || "Unknown error";
+
       Logger.error(
-        `logger: keycloak service account auth returned with ${e.response.status}, ${e.response.data.error_description}, `,
+        `Keycloak service account auth failed: HTTP ${status} - ${description}`,
       );
 
-      throw new HttpException(
-        `Service account failed to authenticate`,
-        e.response.status,
-      );
+      throw new HttpException(`Service account failed to authenticate`, status);
     }
   }
 

--- a/apps/user/src/auth/auth.spec.int.ts
+++ b/apps/user/src/auth/auth.spec.int.ts
@@ -76,6 +76,40 @@ describe("AuthService", () => {
     expect(httpService.post).toHaveBeenCalledTimes(1);
   });
 
+  it("should throw HttpException on network error without crashing (no e.response)", async () => {
+    (httpService.post as jest.Mock).mockReturnValue(
+      throwError(() => {
+        const error: any = new Error("Network Error");
+        // No error.response - simulates DNS failure, connection refused, etc.
+        return error;
+      }),
+    );
+
+    await expect(authService.getToken()).rejects.toThrow(HttpException);
+    expect(httpService.post).toHaveBeenCalledTimes(1);
+  });
+
+  it("should set tokenExpiresAt correctly using addition not multiplication", async () => {
+    const expiresIn = 3600;
+    const before = Date.now();
+
+    (httpService.post as jest.Mock).mockReturnValue(
+      of({
+        data: {
+          access_token: "mockedAccessToken",
+          expires_in: expiresIn,
+        },
+      }),
+    );
+
+    await authService.getToken();
+    const after = Date.now();
+
+    const expiresAt = (authService as any).tokenExpiresAt;
+    expect(expiresAt).toBeGreaterThanOrEqual(before + expiresIn * 1000);
+    expect(expiresAt).toBeLessThanOrEqual(after + expiresIn * 1000);
+  });
+
   it("should throw HttpException if Keycloak returns an error", async () => {
     (httpService.post as jest.Mock).mockReturnValue(
       throwError(() => {

--- a/apps/user/src/main.ts
+++ b/apps/user/src/main.ts
@@ -1,4 +1,4 @@
-import { Logger } from "@nestjs/common";
+import { Logger, ValidationPipe } from "@nestjs/common";
 import { NestFactory } from "@nestjs/core";
 import { AppModule } from "./app.module";
 import { setupSwagger } from "@utils/swagger";
@@ -15,8 +15,8 @@ async function bootstrap() {
   const corsOptions = {
     origin:
       process.env.NODE_ENV === "production"
-        ? process.env.CORS_ORIGINS?.split(",").map(origin => origin.trim())
-        : process.env.CORS_ORIGINS_DEV?.split(",").map(origin =>
+        ? process.env.CORS_ORIGINS?.split(",").map((origin) => origin.trim())
+        : process.env.CORS_ORIGINS_DEV?.split(",").map((origin) =>
             origin.trim(),
           ) || [
             "http://localhost:3000",
@@ -30,6 +30,9 @@ async function bootstrap() {
     optionsSuccessStatus: 204,
   };
 
+  app.useGlobalPipes(
+    new ValidationPipe({ whitelist: true, forbidNonWhitelisted: false }),
+  );
   app.enableCors(corsOptions);
   await app.listen(port, "0.0.0.0");
   Logger.log(
@@ -39,7 +42,7 @@ async function bootstrap() {
   );
 }
 
-bootstrap().catch(err => {
+bootstrap().catch((err) => {
   Logger.error(`Failed to start application: ${err.message}`);
   process.exit(1);
 });

--- a/apps/user/src/user/user.controller.spec.int.ts
+++ b/apps/user/src/user/user.controller.spec.int.ts
@@ -1,6 +1,11 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { HttpModule } from "@nestjs/axios";
-import { HttpException, HttpStatus, INestApplication } from "@nestjs/common";
+import {
+  HttpException,
+  HttpStatus,
+  INestApplication,
+  ValidationPipe,
+} from "@nestjs/common";
 import supertest from "supertest";
 import { UserService } from "./user.service";
 import { AuthService } from "../auth/auth.service";
@@ -22,6 +27,7 @@ describe("User Registration Integration Tests", () => {
       .compile();
 
     app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
     userService = moduleFixture.get<UserService>(UserService);
     authService = moduleFixture.get<AuthService>(AuthService);
     await app.init();
@@ -57,7 +63,30 @@ describe("User Registration Integration Tests", () => {
       .post("/register")
       .send(registerUserDto)
       .expect(HttpStatus.CREATED)
-      .expect(response => {
+      .expect((response) => {
+        expect(response.body).toEqual(mockResponse);
+      });
+  });
+
+  it("should register a user without firstName/lastName (web app payload)", async () => {
+    const mockResponse = {
+      success: true,
+      message: "User created successfully!",
+    };
+
+    jest.spyOn(userService, "createUser").mockResolvedValue(mockResponse);
+
+    const minimalDto = {
+      username: "webuser",
+      email: "webuser@example.com",
+      password: "securepassword123",
+    };
+
+    await supertest(app.getHttpServer())
+      .post("/register")
+      .send(minimalDto)
+      .expect(HttpStatus.CREATED)
+      .expect((response) => {
         expect(response.body).toEqual(mockResponse);
       });
   });
@@ -84,7 +113,7 @@ describe("User Registration Integration Tests", () => {
       .post("/register")
       .send(registerUserDto)
       .expect(HttpStatus.CONFLICT)
-      .expect(response => {
+      .expect((response) => {
         expect(response.body.message).toBe("User already exists");
       });
   });
@@ -112,7 +141,7 @@ describe("User Registration Integration Tests", () => {
       .post("/register")
       .send(registerUserDto)
       .expect(HttpStatus.FORBIDDEN)
-      .expect(response => {
+      .expect((response) => {
         expect(response.body.message).toBe("Error creating user");
       });
   });
@@ -139,7 +168,7 @@ describe("User Registration Integration Tests", () => {
       .post("/register")
       .send(registerUserDto)
       .expect(HttpStatus.FORBIDDEN)
-      .expect(response => {
+      .expect((response) => {
         expect(response.body.message).toBe("Error creating user");
       });
   });
@@ -160,31 +189,24 @@ describe("User Registration Integration Tests", () => {
         .post("/login")
         .send(loginDto)
         .expect(HttpStatus.OK)
-        .expect(response => {
+        .expect((response) => {
           // Adjust this based on actual controller output
           expect(response.body.access_token).toBe(mockToken);
         });
     });
 
-    it("should return 400 if credentials are missing", async () => {
+    it("should return 400 if credentials are missing (ValidationPipe rejects empty fields)", async () => {
       const loginDto = {
         username: "",
         password: "",
       };
 
-      const mockError = new HttpException(
-        "Missing credentials",
-        HttpStatus.BAD_REQUEST,
-      );
-
-      jest.spyOn(userService, "loginUser").mockRejectedValue(mockError);
-
       await supertest(app.getHttpServer())
         .post("/login")
         .send(loginDto)
         .expect(HttpStatus.BAD_REQUEST)
-        .expect(response => {
-          expect(response.body.message).toBe("Missing credentials");
+        .expect((response) => {
+          expect(Array.isArray(response.body.message)).toBe(true);
         });
     });
 
@@ -205,8 +227,18 @@ describe("User Registration Integration Tests", () => {
         .post("/login")
         .send(loginDto)
         .expect(HttpStatus.UNAUTHORIZED)
-        .expect(response => {
+        .expect((response) => {
           expect(response.body.message).toBe("Invalid username or password");
+        });
+    });
+
+    it("should return 400 if login body is entirely missing", async () => {
+      await supertest(app.getHttpServer())
+        .post("/login")
+        .send({})
+        .expect(HttpStatus.BAD_REQUEST)
+        .expect((response) => {
+          expect(Array.isArray(response.body.message)).toBe(true);
         });
     });
 
@@ -227,7 +259,7 @@ describe("User Registration Integration Tests", () => {
         .post("/login")
         .send(loginDto)
         .expect(HttpStatus.INTERNAL_SERVER_ERROR)
-        .expect(response => {
+        .expect((response) => {
           expect(response.body.message).toBe("Internal server error");
         });
     });

--- a/apps/user/src/user/user.service.ts
+++ b/apps/user/src/user/user.service.ts
@@ -1,4 +1,5 @@
 import { HttpException, HttpStatus, Injectable, Logger } from "@nestjs/common";
+import { LoginUserDto } from "@dtos/login-user.dto";
 import { RegisterUserDto } from "@dtos/register-user.dto";
 import { HttpService } from "@nestjs/axios";
 import { firstValueFrom } from "rxjs";
@@ -14,7 +15,7 @@ export class UserService {
     private authService: AuthService,
   ) {}
 
-  public async loginUser(loginUserDto) {
+  public async loginUser(loginUserDto: LoginUserDto) {
     if (!loginUserDto.username || !loginUserDto.password) {
       throw new HttpException("Missing credentials", HttpStatus.BAD_REQUEST);
     }
@@ -52,6 +53,10 @@ export class UserService {
       }
       return { access_token };
     } catch (error: any) {
+      if (error instanceof HttpException) {
+        throw error;
+      }
+
       const status = error.response?.status || HttpStatus.INTERNAL_SERVER_ERROR;
       const message =
         error.response?.data?.error_description ||
@@ -108,18 +113,36 @@ export class UserService {
       if (response?.status === 201) {
         return { success: true, message: "User created successfully!" };
       }
+
+      throw new HttpException(
+        "Unexpected response from identity provider",
+        HttpStatus.BAD_GATEWAY,
+      );
     } catch (error: any) {
-      const errorMessage = error.response?.data?.errorMessage || error.message;
-      if (error.status === 409) {
-        // user already exists
-        throw new HttpException(errorMessage, 409);
-      } else {
-        // Logger.error(errorMessage);
+      if (error instanceof HttpException) {
+        throw error;
+      }
+
+      const errorMessage =
+        error.response?.data?.errorMessage || error.message || "Unknown error";
+
+      if (error.response?.status === 409) {
+        Logger.warn(
+          `User registration conflict: ${errorMessage}`,
+          UserService.name,
+        );
         throw new HttpException(
-          "Error creating user",
-          HttpStatusCode.Forbidden,
+          errorMessage || "User already exists",
+          HttpStatus.CONFLICT,
         );
       }
+
+      Logger.error(
+        `User creation failed: ${errorMessage}`,
+        undefined,
+        UserService.name,
+      );
+      throw new HttpException("Error creating user", HttpStatusCode.Forbidden);
     }
   }
 }


### PR DESCRIPTION
## Changes in this update

### Bug fixes
- Fix crash in auth service when `e.response` is undefined on network errors  
- Fix token expiry arithmetic (multiplication replaced with addition)  
- Fix 409 detection using `error.response?.status` instead of `error.status`  
- Guard `HttpException` re‑throws to preserve original status codes  
- Restore `Logger.error` in `createUser`; handle non‑201 Keycloak responses  

### Improvements & validations
- Add global `ValidationPipe` to enforce DTO validators  
- Make `firstName`/`lastName` optional in `RegisterUserDto` to match web app payload  
- Add `@IsEmail()` and `@MinLength(8)` to `RegisterUserDto`  

### Tests
- Add regression tests for network error, token expiry, and register validation

resolves #726 