### PR TITLE
stop repeated ChromeDriver downloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ web-build/
 # Yarn 4+ internal files
 .yarn/install-state.gz
 .swp
+
+
+.cache

--- a/apps/bdd/wdio.web.conf.ts
+++ b/apps/bdd/wdio.web.conf.ts
@@ -6,8 +6,15 @@ export const config: Options.Testrunner = {
   ...baseConfig,
 
   capabilities: CAPABILITY_WEB_CHROME,
-
-  services: [],
+  cacheDir: "../../.cache/webdriver",
+  services: [
+    [
+      "chromedriver",
+      {
+        version: "147",
+      },
+    ],
+  ],
 
   cucumberOpts: {
     ...baseConfig.cucumberOpts,


### PR DESCRIPTION
Stop repeated ChromeDriver downloads by enabling reuse of cached ChromeDriver across runs.


## Notes

This change improves local test performance but may require adjustments in CI configuration to ensure the cached ChromeDriver is properly resolved in the CI environment.

resolves #741 