### PR TITLE
local chromedriver cache for web WDIO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,6 @@ web-build/
 
 # Yarn 4+ internal files
 .yarn/install-state.gz
+.yarn/.cache
 .swp
+

--- a/apps/bdd/wdio.web.conf.ts
+++ b/apps/bdd/wdio.web.conf.ts
@@ -6,8 +6,16 @@ export const config: Options.Testrunner = {
   ...baseConfig,
 
   capabilities: CAPABILITY_WEB_CHROME,
+  cacheDir: "../../.yarn/.cache/webdriver",
 
-  services: [],
+  services: [
+    [
+      "chromedriver",
+      {
+        version: "147",
+      },
+    ],
+  ],
 
   cucumberOpts: {
     ...baseConfig.cucumberOpts,


### PR DESCRIPTION

This PR configures local web BDD runs to reuse chromedriver from a persistent Yarn cache path, reducing repeated driver downloads.

**What changed**

- Added cacheDir: "../../.yarn/.cache/webdriver"
- Enabled chromedriver service with pinned version 147


resolves #742 