### PR TITLE
chore(ci): add android bdd e2e workflow with gh-pages report

### DIFF
--- a/.github/workflows/ci-cd-pr-bdd-android.yml
+++ b/.github/workflows/ci-cd-pr-bdd-android.yml
@@ -1,0 +1,226 @@
+# Runs Android BDD e2e tests on PRs and on main pushes.
+# Builds the debug APK in CI, boots an Android emulator, runs Appium + BDD tests,
+# and publishes the HTML report to GitHub Pages under /webdriver/android/.
+
+name: PR CI BDD Android e2e tests
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - edited
+      - ready_for_review
+    paths:
+      - "apps/bdd/**"
+      - "apps/native/**"
+      - "packages/core/**"
+      - "packages/wallet/**"
+      - "package.json"
+      - "yarn.lock"
+      - ".github/workflows/ci-cd-pr-bdd-android.yml"
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: gh-pages-deploy
+  cancel-in-progress: false
+
+jobs:
+  android-bdd-e2e-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    if: github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name == github.repository
+    env:
+      NODE_TLS_REJECT_UNAUTHORIZED: "0"
+      PROJECT_ROOT_ANDROID: ${{ github.workspace }}/apps/native
+      NEXT_PUBLIC_TREETRACKER_WALLET_API: ${{ vars.NEXT_PUBLIC_TREETRACKER_WALLET_API }}
+      NEXT_PUBLIC_TREETRACKER_USER_API: ${{ vars.NEXT_PUBLIC_TREETRACKER_USER_API }}
+      NEXT_PUBLIC_ENV: ${{ vars.NEXT_PUBLIC_ENV }}
+      NEXT_PUBLIC_API_TIMEOUT: ${{ vars.NEXT_PUBLIC_API_TIMEOUT }}
+      NEXT_PUBLIC_API_RETRIES: ${{ vars.NEXT_PUBLIC_API_RETRIES }}
+      NEXT_PUBLIC_BASE_URL: ${{ vars.NEXT_PUBLIC_BASE_URL }}
+      CORS_ORIGINS_DEV: ${{ vars.CORS_ORIGINS_DEV }}
+      PRIVATE_KEYCLOAK_REALM: ${{ secrets.PRIVATE_KEYCLOAK_REALM }}
+      PRIVATE_KEYCLOAK_BASE_URL: ${{ secrets.PRIVATE_KEYCLOAK_BASE_URL }}
+      PRIVATE_KEYCLOAK_CLIENT_SECRET: ${{ secrets.PRIVATE_KEYCLOAK_CLIENT_SECRET }}
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      PRIVATE_KEYCLOAK_CLIENT_ID: ${{ secrets.PRIVATE_KEYCLOAK_CLIENT_ID }}
+      PRIVATE_WALLET_API_KEY: ${{ secrets.PRIVATE_WALLET_API_KEY }}
+
+    steps:
+      - name: Checkout repository (PR head)
+        if: github.event_name == 'pull_request_target'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+
+      - name: Checkout repository (default)
+        if: github.event_name != 'pull_request_target'
+        uses: actions/checkout@v4
+
+      - name: Enable KVM group perms
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Use Node.js 24.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24.x"
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Cache Yarn, Gradle, AVD
+        uses: actions/cache@v4
+        with:
+          path: |
+            .yarn/cache
+            .yarn/unplugged
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: android-bdd-${{ runner.os }}-${{ hashFiles('yarn.lock', 'apps/native/android/**/*.gradle*') }}
+          restore-keys: |
+            android-bdd-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Expo prebuild (generate android/ios folders)
+        run: yarn prebuild
+
+      - name: Build Android debug APK
+        run: yarn build-apk-android
+
+      - name: Start user service in the background
+        run: |
+          mkdir -p .logs
+          nohup yarn user:dev > .logs/user.log 2>&1 &
+          echo $! > .logs/user.pid
+          npx wait-on tcp:8080 --timeout 60000
+
+      - name: Start Metro bundler (Expo) in background
+        run: |
+          nohup yarn native:start --port 8081 > .logs/metro.log 2>&1 &
+          echo $! > .logs/metro.pid
+          npx wait-on http://localhost:8081/status --timeout 60000
+
+      - name: Run Android BDD tests on emulator
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 34
+          target: google_apis
+          arch: x86_64
+          profile: pixel_6
+          avd-name: Pixel_9a
+          force-avd-creation: false
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
+          script: |
+            adb reverse tcp:8081 tcp:8081
+            adb reverse tcp:8080 tcp:8080
+            adb install -r apps/native/android/app/build/outputs/apk/debug/app-debug.apk
+            adb shell pm clear com.gtw.app
+            adb shell am start -n com.gtw.app/com.gtw.app.MainActivity
+            yarn bdd:test:android:report
+
+      - name: Stop background services
+        if: always()
+        run: |
+          if [ -f .logs/metro.pid ]; then kill "$(cat .logs/metro.pid)" || true; fi
+          if [ -f .logs/user.pid ]; then kill "$(cat .logs/user.pid)" || true; fi
+
+      - name: Deploy PR Android WebDriver report to GitHub Pages
+        if: always() && github.event_name == 'pull_request_target'
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: apps/bdd/test-artifacts/reports/android/cucumber-html
+          destination_dir: webdriver/android/pr-${{ github.event.pull_request.number }}
+          keep_files: true
+          enable_jekyll: false
+
+      - name: Deploy production Android WebDriver report to GitHub Pages
+        if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: apps/bdd/test-artifacts/reports/android/cucumber-html
+          destination_dir: webdriver/android/prod
+          keep_files: true
+          enable_jekyll: false
+
+      - name: Pin Android report link on PR
+        if: always() && github.event_name == 'pull_request_target'
+        uses: actions/github-script@v7
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const prNumber = context.payload.pull_request.number;
+            const base = `https://${owner}.github.io/${repo}/webdriver/android`;
+            const prUrl = `${base}/pr-${prNumber}/index.html`;
+            const prodUrl = `${base}/prod/index.html`;
+            const marker = "<!-- webdriver-android-report-links -->";
+            const body = `${marker}
+            ## Android WebDriver Report Links
+            - PR report (dev): ${prUrl}
+            - Production report: ${prodUrl}
+            - Workflow status: ${process.env.JOB_STATUS}`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner,
+              repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+
+            const matches = comments.filter(c => c.body?.includes(marker));
+            const [existing, ...duplicates] = matches.sort(
+              (a, b) => new Date(b.created_at) - new Date(a.created_at),
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+              for (const dup of duplicates) {
+                await github.rest.issues.deleteComment({
+                  owner,
+                  repo,
+                  comment_id: dup.id,
+                });
+              }
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: prNumber,
+                body,
+              });
+            }


### PR DESCRIPTION
Add android bdd e2e workflow, that runs
the Appium + WebdriverIO BDD suite against an Android emulator in CI and
publishes the HTML cucumber report to GitHub Pages under
`/webdriver/android/{pr-<N>, prod}/`.
resolves #753 