### PR TITLE
ci: add queue deploy workflow for dev env with db-migrate (#677)

### DIFF
--- a/.github/workflows/ci-cd-deploy-queue-dev.yml
+++ b/.github/workflows/ci-cd-deploy-queue-dev.yml
@@ -1,0 +1,39 @@
+# This workflow deploys the queue package database migration to the dev environment.
+# The queue package has no API server — deployment means running db-migrate
+# to create/update the queue schema, message table, and NOTIFY trigger.
+
+name: Deploy Queue to dev env
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "packages/queue/database/**"
+      - ".github/workflows/ci-cd-deploy-queue-dev.yml"
+  workflow_dispatch:
+
+jobs:
+  migrate:
+    name: Run Queue Migration (dev)
+    runs-on: ubuntu-latest
+    env:
+      DATABASE_URL: ${{ secrets.QUEUE_DATABASE_URL_DEV }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20.x"
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Run db-migrate up
+        run: yarn workspace queue db-migrate-ci

--- a/packages/queue/database/migrations/20260429000000-CreateQueueSchema.js
+++ b/packages/queue/database/migrations/20260429000000-CreateQueueSchema.js
@@ -1,0 +1,33 @@
+const fs = require("fs");
+const path = require("path");
+
+function readFileAsText(filePath) {
+  return new Promise((resolve, reject) => {
+    fs.readFile(filePath, { encoding: "utf-8" }, (err, data) => {
+      if (err) return reject(err);
+      resolve(data);
+    });
+  });
+}
+
+exports.up = async function (db) {
+  const filePath = path.join(
+    __dirname,
+    "sqls",
+    "20260429000000-CreateQueueSchema-up.sql",
+  );
+  const sql = await readFileAsText(filePath);
+  return db.runSql(sql);
+};
+
+exports.down = async function (db) {
+  const filePath = path.join(
+    __dirname,
+    "sqls",
+    "20260429000000-CreateQueueSchema-down.sql",
+  );
+  const sql = await readFileAsText(filePath);
+  return db.runSql(sql);
+};
+
+exports._meta = { version: 1 };

--- a/packages/queue/database/migrations/sqls/20260429000000-CreateQueueSchema-down.sql
+++ b/packages/queue/database/migrations/sqls/20260429000000-CreateQueueSchema-down.sql
@@ -1,0 +1,4 @@
+DROP TRIGGER IF EXISTS message_notify ON queue.message;
+DROP FUNCTION IF EXISTS queue.notify_new_message();
+DROP TABLE IF EXISTS queue.message;
+DROP SCHEMA IF EXISTS queue;

--- a/packages/queue/database/migrations/sqls/20260429000000-CreateQueueSchema-up.sql
+++ b/packages/queue/database/migrations/sqls/20260429000000-CreateQueueSchema-up.sql
@@ -1,0 +1,31 @@
+-- Enable pgcrypto extension for gen_random_uuid() on PostgreSQL < 13
+-- (On PostgreSQL 13+, gen_random_uuid() is built-in; this is a no-op)
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+-- Create the queue schema
+CREATE SCHEMA IF NOT EXISTS queue;
+
+-- Create the message table
+CREATE TABLE IF NOT EXISTS queue.message (
+  id         UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  channel    TEXT NOT NULL,
+  data       JSONB NOT NULL DEFAULT '{}'::jsonb,
+  ack        JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Create a trigger function that sends a NOTIFY with the new row as payload
+CREATE OR REPLACE FUNCTION queue.notify_new_message()
+RETURNS TRIGGER AS $$
+BEGIN
+  PERFORM pg_notify(NEW.channel, row_to_json(NEW)::text);
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Attach the trigger to the message table (drop first to make idempotent)
+DROP TRIGGER IF EXISTS message_notify ON queue.message;
+CREATE TRIGGER message_notify
+  AFTER INSERT ON queue.message
+  FOR EACH ROW
+  EXECUTE FUNCTION queue.notify_new_message();

--- a/packages/queue/package.json
+++ b/packages/queue/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "jest /__tests__/index.spec.js",
+    "db-migrate-ci": "cd database && db-migrate up",
     "pre-commit": "lint-staged",
     "prettier": "prettier --write ."
   },
@@ -16,6 +17,8 @@
     "pg": "^8.7.1"
   },
   "devDependencies": {
+    "db-migrate": "^0.11.14",
+    "db-migrate-pg": "^1.5.2",
     "jest": "^29.7.0",
     "lint-staged": "^15.2.11",
     "prettier": "^3.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8407,7 +8407,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"asn1@npm:~0.2.3":
+"asn1@npm:^0.2.4, asn1@npm:~0.2.3":
   version: 0.2.6
   resolution: "asn1@npm:0.2.6"
   dependencies:
@@ -8489,6 +8489,22 @@ __metadata:
   version: 1.0.1
   resolution: "async-limiter@npm:1.0.1"
   checksum: 10c0/0693d378cfe86842a70d4c849595a0bb50dc44c11649640ca982fa90cbfc74e3cc4753b5a0847e51933f2e9c65ce8e05576e75e5e1fd963a086e673735b35969
+  languageName: node
+  linkType: hard
+
+"async@npm:3.2.3":
+  version: 3.2.3
+  resolution: "async@npm:3.2.3"
+  checksum: 10c0/109780c846f05109dde14412d916ae4ed6daf6f9aad0c4aa1dcf0d4da775a3a9e35e0e06e4e06ad9fed66f99ca15549da16f2f243c56103b346e9d3bcd9c943f
+  languageName: node
+  linkType: hard
+
+"async@npm:^2.6.4":
+  version: 2.6.4
+  resolution: "async@npm:2.6.4"
+  dependencies:
+    lodash: "npm:^4.17.14"
+  checksum: 10c0/0ebb3273ef96513389520adc88e0d3c45e523d03653cc9b66f5c46f4239444294899bfd13d2b569e7dbfde7da2235c35cf5fd3ece9524f935d41bbe4efccdad0
   languageName: node
   linkType: hard
 
@@ -8998,7 +9014,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bcrypt-pbkdf@npm:^1.0.0":
+"bcrypt-pbkdf@npm:^1.0.0, bcrypt-pbkdf@npm:^1.0.2":
   version: 1.0.2
   resolution: "bcrypt-pbkdf@npm:1.0.2"
   dependencies:
@@ -9067,7 +9083,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bluebird@npm:3.7.2, bluebird@npm:^3.7.2":
+"bluebird@npm:3.7.2, bluebird@npm:^3.1.1, bluebird@npm:^3.7.2":
   version: 3.7.2
   resolution: "bluebird@npm:3.7.2"
   checksum: 10c0/680de03adc54ff925eaa6c7bb9a47a0690e8b5de60f4792604aae8ed618c65e6b63a7893b57ca924beaf53eee69c5af4f8314148c08124c550fe1df1add897d2
@@ -9420,7 +9436,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"camelcase@npm:^5.3.1":
+"camelcase@npm:^5.0.0, camelcase@npm:^5.3.1":
   version: 5.3.1
   resolution: "camelcase@npm:5.3.1"
   checksum: 10c0/92ff9b443bfe8abb15f2b1513ca182d16126359ad4f955ebc83dc4ddcc4ef3fdd2c078bc223f2673dc223488e75c99b16cc4d056624374b799e6a1555cf61b23
@@ -9886,6 +9902,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cliui@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "cliui@npm:6.0.0"
+  dependencies:
+    string-width: "npm:^4.2.0"
+    strip-ansi: "npm:^6.0.0"
+    wrap-ansi: "npm:^6.2.0"
+  checksum: 10c0/35229b1bb48647e882104cac374c9a18e34bbf0bace0e2cf03000326b6ca3050d6b59545d91e17bfe3705f4a0e2988787aa5cde6331bf5cbbf0164732cef6492
+  languageName: node
+  linkType: hard
+
 "cliui@npm:^7.0.2":
   version: 7.0.4
   resolution: "cliui@npm:7.0.4"
@@ -10011,6 +10038,13 @@ __metadata:
   version: 2.0.20
   resolution: "colorette@npm:2.0.20"
   checksum: 10c0/e94116ff33b0ff56f3b83b9ace895e5bf87c2a7a47b3401b8c3f3226e050d5ef76cf4072fb3325f9dc24d1698f9b730baf4e05eeaf861d74a1883073f4c98a40
+  languageName: node
+  linkType: hard
+
+"colors@npm:1.0.x":
+  version: 1.0.3
+  resolution: "colors@npm:1.0.3"
+  checksum: 10c0/f9e40dd8b3e1a65378a7ced3fced15ddfd60aaf38e99a7521a7fdb25056b15e092f651cd0f5aa1e9b04fa8ce3616d094e07fc6c2bb261e24098db1ddd3d09a1d
   languageName: node
   linkType: hard
 
@@ -10427,6 +10461,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cpu-features@npm:0.0.2":
+  version: 0.0.2
+  resolution: "cpu-features@npm:0.0.2"
+  dependencies:
+    nan: "npm:^2.14.1"
+    node-gyp: "npm:latest"
+  checksum: 10c0/54e6b66bcb3e046ce39a0116ddfde209a77202574ecedc820128021ff56e1022601d666721545342e0d08922b748a33d43c7c1e7d0040079c3c431a8bafe4b3a
+  languageName: node
+  linkType: hard
+
 "crc-32@npm:^1.2.0":
   version: 1.2.2
   resolution: "crc-32@npm:1.2.2"
@@ -10667,6 +10711,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cycle@npm:1.0.x":
+  version: 1.0.3
+  resolution: "cycle@npm:1.0.3"
+  checksum: 10c0/f38aae412cea9e895e963e0ff8d4d19852e53b630e7fc1dd078da551f3a4c0a98c5f026d4626dfc0b42648b804dabf13a56faace60b09cf6f3cc706c0819f119
+  languageName: node
+  linkType: hard
+
 "cypress@npm:14.0.0":
   version: 14.0.0
   resolution: "cypress@npm:14.0.0"
@@ -10824,6 +10875,59 @@ __metadata:
   languageName: node
   linkType: hard
 
+"db-migrate-base@npm:^2.3.0":
+  version: 2.3.1
+  resolution: "db-migrate-base@npm:2.3.1"
+  dependencies:
+    bluebird: "npm:^3.1.1"
+  checksum: 10c0/8989cc533909bda0d1012966161306b87a89b4e445da871f6553a0a6a0b0a0ad1d47fbf41fbbd22ede3fb0ff6a6fa3110ae686a0275e8a69c66ba2628ac765ff
+  languageName: node
+  linkType: hard
+
+"db-migrate-pg@npm:^1.5.2":
+  version: 1.5.2
+  resolution: "db-migrate-pg@npm:1.5.2"
+  dependencies:
+    bluebird: "npm:^3.1.1"
+    db-migrate-base: "npm:^2.3.0"
+    pg: "npm:^8.11.2"
+    semver: "npm:^7.5.4"
+  checksum: 10c0/5ead3e0064e7897f8ca400855e47c6ae27db4e5ef3db2fc758b69cd7a763fb0778264ecdd8d1f2d0c78c8bcdce2ebcea953a88d5097bb8112469dc89989fcae6
+  languageName: node
+  linkType: hard
+
+"db-migrate-shared@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "db-migrate-shared@npm:1.2.0"
+  checksum: 10c0/7be0cf6ed1e78e59b14b843807fbc59d1dc6ea5f55ff65141dcf61d2c2384041f92ac96f3d5597a11b4580e1d219769d6b25bf54a85dc6395c1414223b18cf85
+  languageName: node
+  linkType: hard
+
+"db-migrate@npm:^0.11.14":
+  version: 0.11.14
+  resolution: "db-migrate@npm:0.11.14"
+  dependencies:
+    balanced-match: "npm:^1.0.0"
+    bluebird: "npm:^3.1.1"
+    db-migrate-shared: "npm:^1.2.0"
+    deep-extend: "npm:^0.6.0"
+    dotenv: "npm:^5.0.1"
+    final-fs: "npm:^1.6.0"
+    inflection: "npm:^1.10.0"
+    mkdirp: "npm:~0.5.0"
+    parse-database-url: "npm:~0.3.0"
+    prompt: "npm:^1.0.0"
+    rc: "npm:^1.2.8"
+    resolve: "npm:^1.1.6"
+    semver: "npm:^5.3.0"
+    tunnel-ssh: "npm:^4.0.0"
+    yargs: "npm:^15.3.1"
+  bin:
+    db-migrate: bin/db-migrate
+  checksum: 10c0/753a8c931767fc93f1b2eb7bf305e8460cd660fcd35068da1d785769d516c84ce0b30d7f0db7051c0f01cec83f693a38c5a9f2bc8fcadd709181c85208654d3f
+  languageName: node
+  linkType: hard
+
 "debug@npm:2.6.9, debug@npm:^2.6.9":
   version: 2.6.9
   resolution: "debug@npm:2.6.9"
@@ -10875,6 +10979,13 @@ __metadata:
   dependencies:
     ms: "npm:^2.1.1"
   checksum: 10c0/37d96ae42cbc71c14844d2ae3ba55adf462ec89fd3a999459dec3833944cd999af6007ff29c780f1c61153bcaaf2c842d1e4ce1ec621e4fc4923244942e4a02a
+  languageName: node
+  linkType: hard
+
+"decamelize@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "decamelize@npm:1.2.0"
+  checksum: 10c0/85c39fe8fbf0482d4a1e224ef0119db5c1897f8503bcef8b826adff7a1b11414972f6fef2d7dec2ee0b4be3863cf64ac1439137ae9e6af23a3d8dcbe26a5b4b2
   languageName: node
   linkType: hard
 
@@ -11314,6 +11425,13 @@ __metadata:
   version: 17.4.2
   resolution: "dotenv@npm:17.4.2"
   checksum: 10c0/164f8e77a646c8446867d5b588d26ea6005c8ea7c5eb41cf926f6113d23f2191355f6e0cfd95ea9bab98394a5b0a3f1e51a8399711b666fe55cc7b0bd745f942
+  languageName: node
+  linkType: hard
+
+"dotenv@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "dotenv@npm:5.0.1"
+  checksum: 10c0/3f111d39bc21d4088bd84183eeb8d6340292669909e41063bbe5ab0726618e9a4879e546e873a0e3193cda9d16bb99ff195a5bf97472cd9bc08368af9bdaa246
   languageName: node
   linkType: hard
 
@@ -13088,6 +13206,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eyes@npm:0.1.x":
+  version: 0.1.8
+  resolution: "eyes@npm:0.1.8"
+  checksum: 10c0/4c79a9cbf45746d8c9f48cc957e35ad8ea336add1c7b8d5a0e002efc791a7a62b27b2188184ef1a1eea7bc3cd06b161791421e0e6c5fe78309705a162c53eea8
+  languageName: node
+  linkType: hard
+
 "fast-deep-equal@npm:^2.0.1":
   version: 2.0.1
   resolution: "fast-deep-equal@npm:2.0.1"
@@ -13324,6 +13449,16 @@ __metadata:
   version: 1.1.0
   resolution: "filter-obj@npm:1.1.0"
   checksum: 10c0/071e0886b2b50238ca5026c5bbf58c26a7c1a1f720773b8c7813d16ba93d0200de977af14ac143c5ac18f666b2cfc83073f3a5fe6a4e996c49e0863d5500fccf
+  languageName: node
+  linkType: hard
+
+"final-fs@npm:^1.6.0":
+  version: 1.6.1
+  resolution: "final-fs@npm:1.6.1"
+  dependencies:
+    node-fs: "npm:~0.1.5"
+    when: "npm:~2.0.1"
+  checksum: 10c0/497538fca2287711b5423af3ecaf71678de6a4cffc80ba35c285a53a7277f001ba00f9b3edb88fdc099a61f71c9b4c78b85a4f044b15b26eff6e50c164c3aab0
   languageName: node
   linkType: hard
 
@@ -13786,7 +13921,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-caller-file@npm:^2.0.5":
+"get-caller-file@npm:^2.0.1, get-caller-file@npm:^2.0.5":
   version: 2.0.5
   resolution: "get-caller-file@npm:2.0.5"
   checksum: 10c0/c6c7b60271931fa752aeb92f2b47e355eac1af3a2673f47c9589e8f8a41adc74d45551c1bc57b5e66a80609f10ffb72b6f575e4370d61cc3f7f3aaff01757cde
@@ -14733,6 +14868,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"inflection@npm:^1.10.0":
+  version: 1.13.4
+  resolution: "inflection@npm:1.13.4"
+  checksum: 10c0/4c579b9ca0079d3f1ae5bca106f009553db3178e5ca46ff6872b270c07fa0a826787be6c50367a2186a578bc9a321d3071fcb5d8ca6d0c63eb8ecbb34f4fdee2
+  languageName: node
+  linkType: hard
+
 "inflight@npm:^1.0.4":
   version: 1.0.6
   resolution: "inflight@npm:1.0.6"
@@ -15482,7 +15624,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"isstream@npm:~0.1.2":
+"isstream@npm:0.1.x, isstream@npm:~0.1.2":
   version: 0.1.2
   resolution: "isstream@npm:0.1.2"
   checksum: 10c0/a6686a878735ca0a48e0d674dd6d8ad31aedfaf70f07920da16ceadc7577b46d67179a60b313f2e6860cb097a2c2eb3cbd0b89e921ae89199a59a17c3273d66f
@@ -17461,6 +17603,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lodash.defaults@npm:^4.1.0":
+  version: 4.2.0
+  resolution: "lodash.defaults@npm:4.2.0"
+  checksum: 10c0/d5b77aeb702caa69b17be1358faece33a84497bcca814897383c58b28a2f8dfc381b1d9edbec239f8b425126a3bbe4916223da2a576bb0411c2cefd67df80707
+  languageName: node
+  linkType: hard
+
 "lodash.difference@npm:^4.5.0":
   version: 4.5.0
   resolution: "lodash.difference@npm:4.5.0"
@@ -17629,7 +17778,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.15, lodash@npm:^4.17.19, lodash@npm:^4.17.21, lodash@npm:^4.17.23":
+"lodash@npm:^4.17.14, lodash@npm:^4.17.15, lodash@npm:^4.17.19, lodash@npm:^4.17.21, lodash@npm:^4.17.23":
   version: 4.18.1
   resolution: "lodash@npm:4.18.1"
   checksum: 10c0/757228fc68805c59789e82185135cf85f05d0b2d3d54631d680ca79ec21944ec8314d4533639a14b8bcfbd97a517e78960933041a5af17ecb693ec6eecb99a27
@@ -18720,7 +18869,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mkdirp@npm:>=0.5 0, mkdirp@npm:^0.5.4":
+"mkdirp@npm:>=0.5 0, mkdirp@npm:^0.5.4, mkdirp@npm:~0.5.0":
   version: 0.5.6
   resolution: "mkdirp@npm:0.5.6"
   dependencies:
@@ -18784,6 +18933,13 @@ __metadata:
   version: 0.7.6
   resolution: "modern-tar@npm:0.7.6"
   checksum: 10c0/1733590c67f31141a7efafd084d82f1da6818f20a7e6edc66623bf9e91b7451f4da079536e3e0e29b20947ea92219cba8d415cea19734edd15fe3bbd874b4846
+  languageName: node
+  linkType: hard
+
+"mongodb-uri@npm:>= 0.9.7":
+  version: 0.9.7
+  resolution: "mongodb-uri@npm:0.9.7"
+  checksum: 10c0/07b10d391b4046b67f804524e07dd6d9163918e36ba39384be3af9e355d8062ad30d406030fe13e6347d4db114e3e4ebfad29fb09ad7cf02024ef3664fbe5b33
   languageName: node
   linkType: hard
 
@@ -18878,7 +19034,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mute-stream@npm:0.0.8":
+"mute-stream@npm:0.0.8, mute-stream@npm:~0.0.4":
   version: 0.0.8
   resolution: "mute-stream@npm:0.0.8"
   checksum: 10c0/18d06d92e5d6d45e2b63c0e1b8f25376af71748ac36f53c059baa8b76ffac31c5ab225480494e7d35d30215ecdb18fed26ec23cafcd2f7733f2f14406bcd19e2
@@ -18900,6 +19056,15 @@ __metadata:
     object-assign: "npm:^4.0.1"
     thenify-all: "npm:^1.0.0"
   checksum: 10c0/103114e93f87362f0b56ab5b2e7245051ad0276b646e3902c98397d18bb8f4a77f2ea4a2c9d3ad516034ea3a56553b60d3f5f78220001ca4c404bd711bd0af39
+  languageName: node
+  linkType: hard
+
+"nan@npm:^2.14.1, nan@npm:^2.15.0":
+  version: 2.27.0
+  resolution: "nan@npm:2.27.0"
+  dependencies:
+    node-gyp: "npm:latest"
+  checksum: 10c0/38eb00b06e40f0c65b6a98d75795f17d651a8b7b52f03873dff6902d0053f12e7638d7f64fc52bda6c8f8ec454d69636e3988c8a9eb2bc749c2d5c255ba55f4c
   languageName: node
   linkType: hard
 
@@ -19181,6 +19346,14 @@ __metadata:
   version: 1.4.0
   resolution: "node-forge@npm:1.4.0"
   checksum: 10c0/67330a5f1f95257a4c8a93b7d555abe87b5f15e350123aa396c97a21a8ca94f9c6549008eb2c73668a91e0d7e3a905785acbd8f8bd0751c29401292011f8f8e1
+  languageName: node
+  linkType: hard
+
+"node-fs@npm:~0.1.5":
+  version: 0.1.7
+  resolution: "node-fs@npm:0.1.7"
+  checksum: 10c0/3cc068c41856bc0d2c77fffa8c7ee0809801aaf1434ad6473bb148d54a5c511677f282b5f1d251d0d5379b46bb48b00cf7abbe6fd1c09cd28ee186fe49726ec5
+  conditions: (os=linux | os=darwin | os=freebsd | os=win32 | os=smartos | os=sunos)
   languageName: node
   linkType: hard
 
@@ -19853,6 +20026,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"parse-database-url@npm:~0.3.0":
+  version: 0.3.0
+  resolution: "parse-database-url@npm:0.3.0"
+  dependencies:
+    mongodb-uri: "npm:>= 0.9.7"
+  checksum: 10c0/f78d29c5fa59383508accb4007d25de5467fc66a7b2dbcd6bacac57c0dfeacd8c9cd1d42e9656809cff3b5cc170a44bf47fb0a89ce66200770f6ffd6cd8212e7
+  languageName: node
+  linkType: hard
+
 "parse-json@npm:^5.0.0, parse-json@npm:^5.2.0":
   version: 5.2.0
   resolution: "parse-json@npm:5.2.0"
@@ -20094,10 +20276,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pg-cloudflare@npm:^1.4.0":
+  version: 1.4.0
+  resolution: "pg-cloudflare@npm:1.4.0"
+  checksum: 10c0/553764d00055052648393cda53c1feb065991d6f9fbfdeb56cf8396c5b33377ab2897aaf5dc9cd3933d09023a1f01e8b1ca755431dcf5fd71c92ea277e2888f1
+  languageName: node
+  linkType: hard
+
 "pg-connection-string@npm:^2.12.0":
   version: 2.12.0
   resolution: "pg-connection-string@npm:2.12.0"
   checksum: 10c0/3a26c62884a9f0464718f652bd5d6bce276ebda830c0fef4de4f88ae73c2507d70cae1d45c2f5b49bebd76187fb4c94f889d07c53fca6acd06b2eecbebcdc336
+  languageName: node
+  linkType: hard
+
+"pg-connection-string@npm:^2.13.0":
+  version: 2.13.0
+  resolution: "pg-connection-string@npm:2.13.0"
+  checksum: 10c0/870f83a8fca06d0340fc522653471d9c7081efbadf25c7f5801fcfb58104ef527138bb5d0546b21498ff4df75a742469622f657911a3b74034a1e94e59f34e31
   languageName: node
   linkType: hard
 
@@ -20117,10 +20313,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pg-pool@npm:^3.14.0":
+  version: 3.14.0
+  resolution: "pg-pool@npm:3.14.0"
+  peerDependencies:
+    pg: ">=8.0"
+  checksum: 10c0/3dd706e67e3b317e29409d9eb3bd44e960eabd86db2a9711a9391bbd43881f8ce7a5f7054a341509558ee05e9bf0a3cc7aef037039da0790ce1e16762ade3ba6
+  languageName: node
+  linkType: hard
+
 "pg-protocol@npm:^1.13.0":
   version: 1.13.0
   resolution: "pg-protocol@npm:1.13.0"
   checksum: 10c0/a4e851e6bb8ff404ca19d561cf49b6b0caf45163bd3f289889edaf6c4e9fb25b08fb57f50d37a8cc86007efcf2cbb3dd2372c97a353a546f45eb49ddebc84fa9
+  languageName: node
+  linkType: hard
+
+"pg-protocol@npm:^1.14.0":
+  version: 1.14.0
+  resolution: "pg-protocol@npm:1.14.0"
+  checksum: 10c0/dccb29b30f5cee8f2ca7dfd17da9eb957174f7a1a25e987e0bfc9fe7640f53dc9fd05c7f3635e7db0c5eefcd41716fffe625f3c1ea9789634d438851b9ce90ae
   languageName: node
   linkType: hard
 
@@ -20134,6 +20346,28 @@ __metadata:
     postgres-date: "npm:~1.0.4"
     postgres-interval: "npm:^1.1.0"
   checksum: 10c0/ab3f8069a323f601cd2d2279ca8c425447dab3f9b61d933b0601d7ffc00d6200df25e26a4290b2b0783b59278198f7dd2ed03e94c4875797919605116a577c65
+  languageName: node
+  linkType: hard
+
+"pg@npm:^8.11.2":
+  version: 8.21.0
+  resolution: "pg@npm:8.21.0"
+  dependencies:
+    pg-cloudflare: "npm:^1.4.0"
+    pg-connection-string: "npm:^2.13.0"
+    pg-pool: "npm:^3.14.0"
+    pg-protocol: "npm:^1.14.0"
+    pg-types: "npm:2.2.0"
+    pgpass: "npm:1.0.5"
+  peerDependencies:
+    pg-native: ">=3.0.1"
+  dependenciesMeta:
+    pg-cloudflare:
+      optional: true
+  peerDependenciesMeta:
+    pg-native:
+      optional: true
+  checksum: 10c0/6b46ae867a3838bf3bb720ef5a3d877bd85de19d90c6f3422e772f56443fc04a4f5b1fa44c9e8544a0f44454971e653d98f4040096e92c378a5aa5a7b07fa0f1
   languageName: node
   linkType: hard
 
@@ -20490,6 +20724,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"prompt@npm:^1.0.0":
+  version: 1.3.0
+  resolution: "prompt@npm:1.3.0"
+  dependencies:
+    "@colors/colors": "npm:1.5.0"
+    async: "npm:3.2.3"
+    read: "npm:1.0.x"
+    revalidator: "npm:0.1.x"
+    winston: "npm:2.x"
+  checksum: 10c0/f2c67178ffd82563dff958b7d9502e6346464675539158e378bd10e236093cbed395099fcfaeb5df8492b06bfd218f46f2ae75796679a127fd6705ee608e72d9
+  languageName: node
+  linkType: hard
+
 "prompts@npm:^2.0.1, prompts@npm:^2.2.1, prompts@npm:^2.3.2":
   version: 2.4.2
   resolution: "prompts@npm:2.4.2"
@@ -20744,6 +20991,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "queue@workspace:packages/queue"
   dependencies:
+    db-migrate: "npm:^0.11.14"
+    db-migrate-pg: "npm:^1.5.2"
     dotenv: "npm:^16.4.7"
     jest: "npm:^29.7.0"
     lint-staged: "npm:^15.2.11"
@@ -21306,6 +21555,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"read@npm:1.0.x":
+  version: 1.0.7
+  resolution: "read@npm:1.0.7"
+  dependencies:
+    mute-stream: "npm:~0.0.4"
+  checksum: 10c0/443533f05d5bb11b36ef1c6d625aae4e2ced8967e93cf546f35aa77b4eb6bd157f4256619e446bae43467f8f6619c7bc5c76983348dffaf36afedf4224f46216
+  languageName: node
+  linkType: hard
+
 "readable-stream@npm:^2.0.2, readable-stream@npm:^2.0.5, readable-stream@npm:^2.2.2, readable-stream@npm:~2.3.6":
   version: 2.3.8
   resolution: "readable-stream@npm:2.3.8"
@@ -21567,6 +21825,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"require-main-filename@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "require-main-filename@npm:2.0.0"
+  checksum: 10c0/db91467d9ead311b4111cbd73a4e67fa7820daed2989a32f7023785a2659008c6d119752d9c4ac011ae07e537eb86523adff99804c5fdb39cd3a017f9b401bb6
+  languageName: node
+  linkType: hard
+
 "requireg@npm:^0.2.2":
   version: 0.2.2
   resolution: "requireg@npm:0.2.2"
@@ -21812,6 +22077,13 @@ __metadata:
   version: 1.1.0
   resolution: "reusify@npm:1.1.0"
   checksum: 10c0/4eff0d4a5f9383566c7d7ec437b671cc51b25963bd61bf127c3f3d3f68e44a026d99b8d2f1ad344afff8d278a8fe70a8ea092650a716d22287e8bef7126bb2fa
+  languageName: node
+  linkType: hard
+
+"revalidator@npm:0.1.x":
+  version: 0.1.8
+  resolution: "revalidator@npm:0.1.8"
+  checksum: 10c0/bb324a169dfd7a6a8503861474c48da55244214391c5e3fd20e37802d9a24ea395ab57d218d26715110e6a834b3ad2dbd3db12bb35e8facaabb876093e9ade2b
   languageName: node
   linkType: hard
 
@@ -22228,6 +22500,13 @@ __metadata:
   version: 0.0.1
   resolution: "server-only@npm:0.0.1"
   checksum: 10c0/4704f0ef85da0be981af6d4ed8e739d39bcfd265b9c246a684060acda5642d0fdc6daffc2308e71e2682c5f508090978802eae0a77623c9b90a49f9ae68048d6
+  languageName: node
+  linkType: hard
+
+"set-blocking@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "set-blocking@npm:2.0.0"
+  checksum: 10c0/9f8c1b2d800800d0b589de1477c753492de5c1548d4ade52f57f1d1f5e04af5481554d75ce5e5c43d4004b80a3eb714398d6907027dc0534177b7539119f4454
   languageName: node
   linkType: hard
 
@@ -22748,6 +23027,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ssh2@npm:1.4.0":
+  version: 1.4.0
+  resolution: "ssh2@npm:1.4.0"
+  dependencies:
+    asn1: "npm:^0.2.4"
+    bcrypt-pbkdf: "npm:^1.0.2"
+    cpu-features: "npm:0.0.2"
+    nan: "npm:^2.15.0"
+  dependenciesMeta:
+    cpu-features:
+      optional: true
+    nan:
+      optional: true
+  checksum: 10c0/52574c15eb86d0fcc48cd0b90cce4244c15f760dcdacf624ca7f7b4d5c15843e6726ecf5d19647710b738f5078375b6709559cfe1fdabd68e4209747b7b9b316
+  languageName: node
+  linkType: hard
+
 "sshpk@npm:^1.18.0":
   version: 1.18.0
   resolution: "sshpk@npm:1.18.0"
@@ -22801,7 +23097,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"stack-trace@npm:0.0.10":
+"stack-trace@npm:0.0.10, stack-trace@npm:0.0.x":
   version: 0.0.10
   resolution: "stack-trace@npm:0.0.10"
   checksum: 10c0/9ff3dabfad4049b635a85456f927a075c9d0c210e3ea336412d18220b2a86cbb9b13ec46d6c37b70a302a4ea4d49e30e5d4944dd60ae784073f1cde778ac8f4b
@@ -24072,6 +24368,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tunnel-ssh@npm:^4.0.0":
+  version: 4.1.6
+  resolution: "tunnel-ssh@npm:4.1.6"
+  dependencies:
+    debug: "npm:2.6.9"
+    lodash.defaults: "npm:^4.1.0"
+    ssh2: "npm:1.4.0"
+  checksum: 10c0/6f8a81765086ddc978296efe5f0512cdf1a712c8748b4a27774a9c95b500e1c15921f9134c07f597b640b926002ef7110364857dbeda74f828bad9a7cd7a58c6
+  languageName: node
+  linkType: hard
+
 "tweetnacl@npm:^0.14.3, tweetnacl@npm:~0.14.0":
   version: 0.14.5
   resolution: "tweetnacl@npm:0.14.5"
@@ -25327,6 +25634,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"when@npm:~2.0.1":
+  version: 2.0.1
+  resolution: "when@npm:2.0.1"
+  checksum: 10c0/4b10d00cd5e014aa6cdf5514e20994370d80192ed34758ca8af22c85f48c8584c0f4f99ffa5428975081070f827c4157266e5df9e549f13f792a728c54f41cc4
+  languageName: node
+  linkType: hard
+
 "which-boxed-primitive@npm:^1.0.2, which-boxed-primitive@npm:^1.1.0, which-boxed-primitive@npm:^1.1.1":
   version: 1.1.1
   resolution: "which-boxed-primitive@npm:1.1.1"
@@ -25370,6 +25684,13 @@ __metadata:
     is-weakmap: "npm:^2.0.2"
     is-weakset: "npm:^2.0.3"
   checksum: 10c0/3345fde20964525a04cdf7c4a96821f85f0cc198f1b2ecb4576e08096746d129eb133571998fe121c77782ac8f21cbd67745a3d35ce100d26d4e684c142ea1f2
+  languageName: node
+  linkType: hard
+
+"which-module@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "which-module@npm:2.0.1"
+  checksum: 10c0/087038e7992649eaffa6c7a4f3158d5b53b14cf5b6c1f0e043dccfacb1ba179d12f17545d5b85ebd94a42ce280a6fe65d0cbcab70f4fc6daad1dfae85e0e6a3e
   languageName: node
   linkType: hard
 
@@ -25436,6 +25757,20 @@ __metadata:
   dependencies:
     execa: "npm:^4.0.2"
   checksum: 10c0/5c0ce2603a85e25e9a5c78eb1ef646aac7036da2fb942643f2120b11fc33ed94fbcdd340b2abbf27daa522efc9e52df36fe95b1c03cd9acd8d6c6c39f88f106b
+  languageName: node
+  linkType: hard
+
+"winston@npm:2.x":
+  version: 2.4.7
+  resolution: "winston@npm:2.4.7"
+  dependencies:
+    async: "npm:^2.6.4"
+    colors: "npm:1.0.x"
+    cycle: "npm:1.0.x"
+    eyes: "npm:0.1.x"
+    isstream: "npm:0.1.x"
+    stack-trace: "npm:0.0.x"
+  checksum: 10c0/8c6f7365955d93a78f3345db9259052fd68c64096898c5787cdd766a26555d869e56c6607db29c85733d342fe86b8e8b65862843cb751391e594752b1565a89b
   languageName: node
   linkType: hard
 
@@ -25663,6 +25998,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"y18n@npm:^4.0.0":
+  version: 4.0.3
+  resolution: "y18n@npm:4.0.3"
+  checksum: 10c0/308a2efd7cc296ab2c0f3b9284fd4827be01cfeb647b3ba18230e3a416eb1bc887ac050de9f8c4fd9e7856b2e8246e05d190b53c96c5ad8d8cb56dffb6f81024
+  languageName: node
+  linkType: hard
+
 "y18n@npm:^5.0.5":
   version: 5.0.8
   resolution: "y18n@npm:5.0.8"
@@ -25714,6 +26056,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"yargs-parser@npm:^18.1.2":
+  version: 18.1.3
+  resolution: "yargs-parser@npm:18.1.3"
+  dependencies:
+    camelcase: "npm:^5.0.0"
+    decamelize: "npm:^1.2.0"
+  checksum: 10c0/25df918833592a83f52e7e4f91ba7d7bfaa2b891ebf7fe901923c2ee797534f23a176913ff6ff7ebbc1cc1725a044cc6a6539fed8bfd4e13b5b16376875f9499
+  languageName: node
+  linkType: hard
+
 "yargs-parser@npm:^20.2.2, yargs-parser@npm:^20.2.4, yargs-parser@npm:^20.2.9":
   version: 20.2.9
   resolution: "yargs-parser@npm:20.2.9"
@@ -25745,6 +26097,25 @@ __metadata:
     y18n: "npm:^5.0.5"
     yargs-parser: "npm:^21.1.1"
   checksum: 10c0/ccd7e723e61ad5965fffbb791366db689572b80cca80e0f96aad968dfff4156cd7cd1ad18607afe1046d8241e6fb2d6c08bf7fa7bfb5eaec818735d8feac8f05
+  languageName: node
+  linkType: hard
+
+"yargs@npm:^15.3.1":
+  version: 15.4.1
+  resolution: "yargs@npm:15.4.1"
+  dependencies:
+    cliui: "npm:^6.0.0"
+    decamelize: "npm:^1.2.0"
+    find-up: "npm:^4.1.0"
+    get-caller-file: "npm:^2.0.1"
+    require-directory: "npm:^2.1.1"
+    require-main-filename: "npm:^2.0.0"
+    set-blocking: "npm:^2.0.0"
+    string-width: "npm:^4.2.0"
+    which-module: "npm:^2.0.0"
+    y18n: "npm:^4.0.0"
+    yargs-parser: "npm:^18.1.2"
+  checksum: 10c0/f1ca680c974333a5822732825cca7e95306c5a1e7750eb7b973ce6dc4f97a6b0a8837203c8b194f461969bfe1fb1176d1d423036635285f6010b392fa498ab2d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION

# Description

This PR introduces ci/cd workflows to deploy the queue database schema to the dev environment. deployment means running `db-migrate` to create/update the postgresql schema, message table, and NOTIFY trigger.

Fixes: #677

---

## Changes Made

- [ ] Changes in **apps** folder (specify the app and briefly describe the changes):
  - [ ] `Web`
  - [ ] `Native`

- [x] Changes in **packages** folder (specify the package and briefly describe the changes):
  - [x] `Queue` — added `db-migrate` setup under database: migration JS loader, idempotent SQL up/down files. Moved `db-migrate` and `db-migrate-pg` to `devDependencies`.

---

### Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update

---

#### Screenshots

N/A — CI/CD and database migration only, no UI changes.

---

### How Has This Been Tested?

- [ ] Cypress integration
- [ ] Cypress component tests
- [ ] Jest unit tests

---

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

---

### Additional Comments

**New files added:**
- ci-cd-deploy-queue-dev.yml — auto-deploys on push to `main` when `packages/queue/database/**` changes
- 20260429000000-CreateQueueSchema-up.sql — idempotent schema creation
- 20260429000000-CreateQueueSchema-down.sql — full teardown in reverse order
- 20260429000000-CreateQueueSchema.js — db-migrate JS loader

**Required secrets:** QUEUE_DATABASE_URL_DEV must be set in the repository.