### PR TITLE
fix: inject Keycloak OIDC config into dev web build

### DIFF
--- a/.github/workflows/static-website-deploy-dev.yml
+++ b/.github/workflows/static-website-deploy-dev.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Set Environment Variables for Build
         run: |
           echo "NEXT_PUBLIC_HOSTNAME=https://wallet-dev.treetracker.org" >> ${{ env.PROJECT_DIRECTORY }}/.env.local
+          echo "NEXT_PUBLIC_KEYCLOAK_URL=https://dev-k8s.treetracker.org/keycloak" >> ${{ env.PROJECT_DIRECTORY }}/.env.local
+          echo "NEXT_PUBLIC_KEYCLOAK_REALM=treetracker" >> ${{ env.PROJECT_DIRECTORY }}/.env.local
+          echo "NEXT_PUBLIC_KEYCLOAK_CLIENT_ID=treetracker-wallet-client-fe" >> ${{ env.PROJECT_DIRECTORY }}/.env.local
           echo "Generated .env.local:"
           cat ${{ env.PROJECT_DIRECTORY }}/.env.local
 

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -9,3 +9,7 @@ NEXT_PUBLIC_TREETRACKER_WALLET_API=https://dev-k8s.treetracker.org/wallet/keyclo
 NODE_TLS_REJECT_UNAUTHORIZED = 0
 # Base URL the token details page links to for a token's location on the map.
 NEXT_PUBLIC_MAP_URL = https://dev.treetracker.org
+
+NEXT_PUBLIC_KEYCLOAK_URL = https://dev-k8s.treetracker.org/keycloak
+NEXT_PUBLIC_KEYCLOAK_REALM = treetracker
+NEXT_PUBLIC_KEYCLOAK_CLIENT_ID = treetracker-wallet-client-fe


### PR DESCRIPTION
# Description

This PR injects the Keycloak browser-OIDC config (`URL` / `REALM` / `CLIENT_ID`) into the
dev build and documents the variables in `.env.example`. This unblocks the
register → login → create wallet → gift token feature end-to-end in the dev environment.

Resolves: #775

---

## Changes Made

- [x] Changes in **`apps`** folder:
  - [x] `Web` — documented the required Keycloak browser-OIDC env vars in
        `apps/web/.env.example` (`NEXT_PUBLIC_KEYCLOAK_URL`, `NEXT_PUBLIC_KEYCLOAK_REALM`,
        `NEXT_PUBLIC_KEYCLOAK_CLIENT_ID`).
  - [ ] `Native`

- [ ] Changes in **`packages`** folder: _none_

- **CI/CD:** `.github/workflows/static-website-deploy-dev.yml` now writes the three
  Keycloak `NEXT_PUBLIC_*` vars into `apps/web/.env.local` before `yarn build`, so the
  static export bakes them into the deployed bundle.

---

### Type of Change

- [x] 🐛 **Bug fix** (non-breaking change which fixes an issue)
- [ ] ✨ **New feature**
- [ ] 💥 **Breaking change**
- [ ] 📝 **Documentation update**

---

#### Screenshots

|                         Before                          |                          After                          |
| :-----------------------------------------------------: | :-----------------------------------------------------: |
| `Application error: a client-side exception` (`clientId missing`) | Keycloak hosted login/registration loads; gift-token flow works |

---

### How Has This Been Tested?

- [ ] Cypress integration
- [ ] Cypress component tests
- [ ] Jest unit tests


---

### Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (`apps/web/.env.example`)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

---

### Additional Comments
No