### PR TITLE
fix(bdd): align Wrong-login scenario with Keycloak hosted login

### DIFF
--- a/apps/bdd/features/login.feature
+++ b/apps/bdd/features/login.feature
@@ -5,7 +5,7 @@ Feature: Wallet app login
   Scenario: Wrong login
     Given I am on the login page
     When I login with foobar and barfoo
-    Then I should see text Login failed
+    Then I should see text Invalid username or password
 
   @skip
   Scenario: Correct login

--- a/apps/bdd/features/step-definitions/steps.ts
+++ b/apps/bdd/features/step-definitions/steps.ts
@@ -59,9 +59,13 @@ Given(/^I am on the (\w+) page$/, async (page: string) => {
 //#region LOGIN
 
 When(/^I login with (\w+) and (.+)$/, async (username, password) => {
-  await $('input[name="username"]').setValue(username);
-  await $('input[name="password"]').setValue(password);
-  await $('button[type="submit"]').click();
+  // The app /login redirects to Keycloak's hosted login page. Use the same
+  // selectors as keycloakLogin(): the submit is <input id="kc-login">, not the
+  // <button type="submit"> the old custom form used.
+  await $("#username").waitForDisplayed({ timeout: 20000 });
+  await $("#username").setValue(username);
+  await $("#password").setValue(password);
+  await $("#kc-login").click();
 });
 
 Then(/^I should see text (.*)$/, async message => {


### PR DESCRIPTION
# Description

After the Keycloak migration the BDD `login.feature` "Wrong login" scenario was failing,which kept the `full-bdd-e2e-tests` job red even though the create-wallet (gift-token) and register scenarios pass. The standalone `I login with … and …` step was never migrated: it still targeted the **old custom form** (`button[type="submit"]`) and asserted the old **"Login failed"** message. On Keycloak's hosted login page the submit is `<input id="kc-login">`, so the click failed (`element wasn't found`), and the error text is **"Invalid username or password."**, not "Login failed".

This aligns the step with Keycloak using `#username` / `#password` / `#kc-login` (the same selectors as the existing `keycloakLogin` helper) — and updates the expected assertion text. With this, the entire BDD web suite goes green.

Resolves: #775

---

## Changes Made

- [x] Changes in **`apps`** folder:
  - [ ] `Web`
  - [ ] `Native`
  - [x] `bdd` — fixed the `I login with … and …` step in
        `apps/bdd/features/step-definitions/steps.ts` (Keycloak selectors) and the expected
        error text in `apps/bdd/features/login.feature`.

- [ ] Changes in **`packages`** folder: _none_

---

### Type of Change

- [x] 🐛 **Bug fix** (non-breaking change which fixes an issue)
- [ ] ✨ **New feature**
- [ ] 💥 **Breaking change**
- [ ] 📝 **Documentation update**

---

#### Screenshots

|                       Before                       |                  After                  |
| :------------------------------------------------: | :-------------------------------------: |
| Wrong-login fails: `Can't call click on element "button[type=submit]" … wasn't found` | Wrong-login passes; full BDD web suite green |

---

### How Has This Been Tested?

- [ ] Cypress integration
- [ ] Cypress component tests
- [ ] Jest unit tests


---

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (rationale on the step)
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective (the fixed Wrong-login scenario)
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

---

### Additional Comments

- The expected text `Invalid username or password` is Keycloak's default classic-theme English
  message (the realm uses the classic theme — register relies on `#kc-register-form` / `#kc-login`).
  If the realm theme/locale changes, this string must be updated accordingly.
- The submit selector `#kc-login` matches the existing `keycloakLogin` helper, keeping all
  login flows consistent.