### PR TITLE
fix: inject wallet API, map and base URLs into dev web build

### DIFF
--- a/.github/workflows/static-website-deploy-dev.yml
+++ b/.github/workflows/static-website-deploy-dev.yml
@@ -47,6 +47,9 @@ jobs:
           echo "NEXT_PUBLIC_KEYCLOAK_URL=https://dev-k8s.treetracker.org/keycloak" >> ${{ env.PROJECT_DIRECTORY }}/.env.local
           echo "NEXT_PUBLIC_KEYCLOAK_REALM=treetracker" >> ${{ env.PROJECT_DIRECTORY }}/.env.local
           echo "NEXT_PUBLIC_KEYCLOAK_CLIENT_ID=treetracker-wallet-client-fe" >> ${{ env.PROJECT_DIRECTORY }}/.env.local
+          echo "NEXT_PUBLIC_TREETRACKER_WALLET_API=https://dev-k8s.treetracker.org/wallet/keycloak" >> ${{ env.PROJECT_DIRECTORY }}/.env.local
+          echo "NEXT_PUBLIC_MAP_URL=https://dev.treetracker.org" >> ${{ env.PROJECT_DIRECTORY }}/.env.local
+          echo "NEXT_PUBLIC_BASE_URL=https://wallet-dev.treetracker.org" >> ${{ env.PROJECT_DIRECTORY }}/.env.local
           echo "Generated .env.local:"
           cat ${{ env.PROJECT_DIRECTORY }}/.env.local
 


### PR DESCRIPTION
# Description

This injects the three missing runtime URLs into the dev build so the deployed app talks to the real wallet API (`https://dev-k8s.treetracker.org/wallet/keycloak`), builds correct map links, and redirects within its own origin.

Resolves: #775

---

## Changes Made

- [ ] Changes in **`apps`** folder: _none_
  - [ ] `Web`
  - [ ] `Native`

- [ ] Changes in **`packages`** folder: _none_

- **CI/CD:** `.github/workflows/static-website-deploy-dev.yml` — add
  `NEXT_PUBLIC_TREETRACKER_WALLET_API`, `NEXT_PUBLIC_MAP_URL`, and `NEXT_PUBLIC_BASE_URL`
  to the build env so they are baked into the static export.

---

### Type of Change

- [x] 🐛 **Bug fix** (non-breaking change which fixes an issue)
- [ ] ✨ **New feature**
- [ ] 💥 **Breaking change**
- [ ] 📝 **Documentation update**

---

#### Screenshots

|                       Before                        |                    After                     |
| :-------------------------------------------------: | :------------------------------------------: |
| Create wallet → `AxiosError: status code 405` (POST hits the static site) | Create wallet → `201`; gift token appears |

---

### How Has This Been Tested?

- [ ] Cypress integration
- [ ] Cypress component tests
- [ ] Jest unit tests


---

### Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

---

### Additional Comments

