### PR TITLE
test: verify token id on web map page in wallet BDD flow

### DIFF
--- a/apps/bdd/features/step-definitions/steps.ts
+++ b/apps/bdd/features/step-definitions/steps.ts
@@ -305,15 +305,17 @@ Then(
   async () => {
     // A new tab opens for the map. Headed Chrome also exposes devtools:// tabs as
     // window handles, so don't assume which handle is the map — scan every handle
-    // and land on the one whose URL carries /tokens/<id>. (The external map app may
-    // return an error page, but the URL still carries the token id.)
+    // and land on the one whose URL carries /tokens/<id>, then verify the page
+    // itself displays that token id.
     await browser.waitUntil(
       async () => {
         const handles = await browser.getWindowHandles();
         for (const h of handles) {
           await browser.switchToWindow(h);
           if ((await browser.getUrl()).includes("/tokens/" + selectedTokenId)) {
-            return true;
+            const body = $("body");
+            await body.waitForDisplayed({ timeout: 10000 });
+            return (await body.getText()).includes(selectedTokenId);
           }
         }
         return false;
@@ -321,10 +323,7 @@ Then(
       {
         timeout: 20000,
         interval: 1000,
-        timeoutMsg:
-          "No tab navigated to the token map page (/tokens/" +
-          selectedTokenId +
-          ")",
+        timeoutMsg: "No map tab displayed token id " + selectedTokenId,
       },
     );
   },

--- a/apps/bdd/wdio.web.conf.ts
+++ b/apps/bdd/wdio.web.conf.ts
@@ -8,14 +8,10 @@ export const config: Options.Testrunner = {
   capabilities: CAPABILITY_WEB_CHROME,
   cacheDir: "../../.yarn/.cache/webdriver",
 
-  services: [
-    [
-      "chromedriver",
-      {
-        version: "147",
-      },
-    ],
-  ],
+  // WebdriverIO v9 has built-in browser-driver management: it auto-resolves and
+  // downloads the Chromedriver matching the locally installed Chrome. The legacy
+  // wdio-chromedriver-service pinned an older driver (148) which broke once local
+  // Chrome auto-updated (150), so it's intentionally omitted here.
 
   cucumberOpts: {
     ...baseConfig.cucumberOpts,


### PR DESCRIPTION
# Description

Improves the wallet web BDD scenario to verify the opened web map page more reliably after clicking a token location.
- Ran `yarn bdd:e2e:wallet` locally.
- The wallet flow now proceeds through the intended wallet-app steps.
- The remaining failing assertion is:
  `Then I should see the map page with the location of the token in a new tab`

Blocked by downstream web map issue:
- Direct repro outside BDD:
  `https://dev.treetracker.org/wallets/0faf4970-ac66-4bbc-a68a-c1e1881211fc/tokens/dd3d75f0-4fa3-403c-9e2b-5c322aa18b45`
- The same failure happens there, so the remaining failure is in web map handling of the token route


Fixes: #784

---

## Changes Made

- [x] Changes in **`apps`** folder (specify the app and briefly describe the
      changes):
  - [x] `Web`

---

### Type of Change

- [x] 🐛 **Bug fix** (non-breaking change which fixes an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 💥 **Breaking change** (fix or feature that would cause existing
      functionality to not work as expected)
- [ ] 📝 **Documentation update** (changes)

---

---

### How Has This Been Tested?

- [ ] Cypress integration
- [ ] Cypress component tests
- [ ] Jest unit tests

---

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

---

### Additional Comments

For fixing `500 Something went wrong` Error in web map I have created a PR https://github.com/Greenstand/treetracker-web-map-client/pull/1834