### PR TITLE
feat: add local k3s wallet web deployment

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -3,6 +3,7 @@ NEXT_PUBLIC_ENV=development
 NEXT_PUBLIC_API_TIMEOUT=10000
 NEXT_PUBLIC_API_RETRIES=3
 NEXT_PUBLIC_BASE_URL=http://localhost:3000
+NEXT_PUBLIC_BASE_PATH=
 
 # Keycloak authentication
 NEXT_PUBLIC_KEYCLOAK_URL=https://dev-k8s.treetracker.org/keycloak

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,9 +1,12 @@
 /** @type {import('next').NextConfig} */
 const path = require("path");
 
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH || "";
+
 const nextConfig = {
   reactStrictMode: true,
   output: "export",
+  basePath,
   transpilePackages: ["wallet_state"],
   serverExternalPackages: ["expo-constants", "expo-modules-core"],
   turbopack: {},

--- a/apps/web/src/auth/keycloak.ts
+++ b/apps/web/src/auth/keycloak.ts
@@ -1,5 +1,7 @@
 import Keycloak from "keycloak-js";
 
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH ?? "";
+
 // Single keycloak-js instance for the app (browser-only). Mirrors the pattern used
 // by treetracker-admin-client: a public client + PKCE, hosted login/registration.
 let keycloak: Keycloak | null = null;
@@ -33,7 +35,7 @@ export function initKeycloak(): Promise<boolean> {
 
 const callbackUri = () =>
   typeof window !== "undefined"
-    ? `${window.location.origin}/auth/callback`
+    ? `${window.location.origin}${basePath}/auth/callback`
     : undefined;
 
 export function login(): void {
@@ -47,7 +49,7 @@ export function register(): void {
 export function logout(): void {
   const redirectUri =
     typeof window !== "undefined"
-      ? `${window.location.origin}/login`
+      ? `${window.location.origin}${basePath}/login`
       : undefined;
   getKeycloak()?.logout({ redirectUri });
 }

--- a/deployment/local/Dockerfile
+++ b/deployment/local/Dockerfile
@@ -1,0 +1,36 @@
+# Build the wallet web workspace as a static Next.js export.
+FROM node:20-alpine AS build
+WORKDIR /app
+
+RUN corepack enable && corepack prepare yarn@4.9.4 --activate
+
+COPY . .
+ENV HUSKY=0 \
+    CYPRESS_INSTALL_BINARY=0
+RUN yarn workspaces focus web
+
+ARG NEXT_PUBLIC_BASE_PATH=/wallet
+ARG NEXT_PUBLIC_BASE_URL=http://localhost:8088/wallet
+ARG NEXT_PUBLIC_TREETRACKER_USER_API=https://dev-k8s.treetracker.org/wallet/user
+ARG NEXT_PUBLIC_TREETRACKER_WALLET_API=https://dev-k8s.treetracker.org/wallet/keycloak
+ARG NEXT_PUBLIC_KEYCLOAK_URL=https://dev-k8s.treetracker.org/keycloak
+ARG NEXT_PUBLIC_KEYCLOAK_REALM=treetracker
+ARG NEXT_PUBLIC_KEYCLOAK_CLIENT_ID=treetracker-wallet-client-fe
+ARG NEXT_PUBLIC_MAP_URL=https://dev.treetracker.org
+
+ENV NEXT_PUBLIC_BASE_PATH=$NEXT_PUBLIC_BASE_PATH \
+    NEXT_PUBLIC_BASE_URL=$NEXT_PUBLIC_BASE_URL \
+    NEXT_PUBLIC_TREETRACKER_USER_API=$NEXT_PUBLIC_TREETRACKER_USER_API \
+    NEXT_PUBLIC_TREETRACKER_WALLET_API=$NEXT_PUBLIC_TREETRACKER_WALLET_API \
+    NEXT_PUBLIC_KEYCLOAK_URL=$NEXT_PUBLIC_KEYCLOAK_URL \
+    NEXT_PUBLIC_KEYCLOAK_REALM=$NEXT_PUBLIC_KEYCLOAK_REALM \
+    NEXT_PUBLIC_KEYCLOAK_CLIENT_ID=$NEXT_PUBLIC_KEYCLOAK_CLIENT_ID \
+    NEXT_PUBLIC_MAP_URL=$NEXT_PUBLIC_MAP_URL
+
+RUN yarn workspace web build
+
+# Emissary strips /wallet before forwarding; nginx serves the static export.
+FROM nginx:1.27-alpine
+COPY deployment/local/nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/apps/web/out /usr/share/nginx/html
+EXPOSE 80

--- a/deployment/local/k8s.yaml
+++ b/deployment/local/k8s.yaml
@@ -1,0 +1,67 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: wallet-app
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: treetracker-wallet-app
+  namespace: wallet-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: treetracker-wallet-app
+  template:
+    metadata:
+      labels:
+        app: treetracker-wallet-app
+    spec:
+      containers:
+        - name: web
+          image: treetracker-wallet-app:local
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 3
+            periodSeconds: 5
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: treetracker-wallet-app
+  namespace: wallet-app
+spec:
+  selector:
+    app: treetracker-wallet-app
+  ports:
+    - port: 80
+      targetPort: 80
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+metadata:
+  name: treetracker-wallet-app
+  namespace: wallet-app
+spec:
+  hostname: "*"
+  prefix: /wallet/
+  rewrite: /
+  service: treetracker-wallet-app.wallet-app:80
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+metadata:
+  name: treetracker-wallet-app-root
+  namespace: wallet-app
+spec:
+  hostname: "*"
+  prefix: /wallet
+  prefix_exact: true
+  rewrite: /
+  service: treetracker-wallet-app.wallet-app:80

--- a/deployment/local/nginx.conf
+++ b/deployment/local/nginx.conf
@@ -1,0 +1,12 @@
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Next.js static export emits route.html files by default.
+    location / {
+        try_files $uri $uri.html $uri/ =404;
+    }
+}


### PR DESCRIPTION
## Summary

- add a multi-stage Yarn/Next.js/nginx image for the wallet web workspace
- add Kubernetes Deployment, Service, readiness probe, and Emissary mappings
- make the Next.js base path configurable and preserve it in Keycloak redirects
- expose the local wallet UI under `/wallet`

## Why

The local k3s environment did not deploy `apps/web`, so the wallet UI was unavailable through the local Emissary gateway.

## Validation

- shell/YAML and diff checks passed in the parent integration
- Docker build was not completed locally because of limited disk space
- Cypress binary installation is disabled in the production image build
