### PR TITLE
feat(wallet): claim shared token by link on first wallet creation

### DIFF
--- a/apps/bdd/features/step-definitions/share-token.steps.ts
+++ b/apps/bdd/features/step-definitions/share-token.steps.ts
@@ -1,0 +1,221 @@
+/**
+ * share-token.steps.ts — implements the stakeholder BDD apps/bdd/features/share-token.feature.
+ *
+ * Sender (seeded) logs in, shares a token by link from the send page ('share by
+ * QR code' checkbox). A second visitor opens the link in an isolated session,
+ * registers, creates a wallet, and the shared token is redeemed into it.
+ */
+import { Given, When, Then } from "@wdio/cucumber-framework";
+import { $, browser, expect } from "@wdio/globals";
+import {
+  seedAccount,
+  seedTokenIntoWalletByName,
+  resetAccount,
+  deleteWalletByName,
+  SeededAccount,
+} from "../../utils/seed.ts";
+
+const SENDER_PASSWORD = "Abcde123$x";
+const RECEIVER_PASSWORD = "Abcde123$";
+const base = () => process.env.E2E_BASE_URL ?? "http://localhost:3000";
+// Keycloak origin, used to drop its SSO cookie so a fresh visitor is isolated.
+const KC_WELL_KNOWN =
+  process.env.BDD_KEYCLOAK_WELL_KNOWN ??
+  "https://dev-k8s.treetracker.org/keycloak/realms/treetracker/.well-known/openid-configuration";
+
+// Shared across steps within the scenario.
+let sharedTokenId = "";
+let sharedLink = "";
+let receiverWallet = "";
+const senders: Record<string, SeededAccount> = {};
+
+// Clear the app session + Keycloak SSO cookie so the next login/registration
+// starts as a brand-new, unauthenticated visitor ("another browser").
+async function clearSession(): Promise<void> {
+  await browser.url(KC_WELL_KNOWN);
+  await browser.deleteAllCookies();
+  await browser.url(`${base()}/login`);
+  await browser.execute(() => {
+    try {
+      window.sessionStorage.clear();
+      window.localStorage.clear();
+    } catch {
+      /* ignore */
+    }
+  });
+  await browser.deleteAllCookies();
+}
+
+// Drive Keycloak's hosted login form, then wait for the app to load logged-in.
+async function keycloakLogin(username: string, password: string): Promise<void> {
+  await $("#username").waitForDisplayed({ timeout: 25000 });
+  await $("#username").setValue(username);
+  await $("#password").setValue(password);
+  await $("#kc-login").click();
+  await $("[data-test=navigation-home]").waitForDisplayed({ timeout: 30000 });
+}
+
+async function loginAs(email: string, password: string): Promise<void> {
+  await clearSession();
+  await browser.url(`${base()}/login`);
+  await keycloakLogin(email, password);
+}
+
+// Fill + submit Keycloak's hosted registration form for a specific email.
+// Assumes the register form is (about to be) displayed.
+async function registerAs(email: string, password: string): Promise<void> {
+  const username = email.split("@")[0];
+  await $("#kc-register-form").waitForExist({ timeout: 25000 });
+  await $("#username").waitForDisplayed({ timeout: 25000 });
+  await $("#firstName").setValue("Share");
+  await $("#lastName").setValue("Receiver");
+  await $("#username").setValue(username);
+  await $("#email").setValue(email);
+  await $("#password").setValue(password);
+  await $("#password-confirm").setValue(password);
+
+  const candidates = [
+    "#kc-register-form input[type=submit]",
+    "#kc-register-form button[type=submit]",
+    "input[type=submit]",
+    "button[type=submit]",
+  ];
+  for (const sel of candidates) {
+    const el = await $(sel);
+    if (await el.isExisting()) {
+      try {
+        await el.click();
+      } catch {
+        await browser.execute((node: HTMLElement) => node.click(), el as never);
+      }
+      break;
+    }
+  }
+  await $("[data-test=navigation-home]").waitForDisplayed({ timeout: 30000 });
+}
+
+async function createWalletUI(name: string): Promise<void> {
+  await browser.url(`${base()}/wallet`);
+  await $("[data-test=wallet-create-open]").waitForDisplayed({ timeout: 15000 });
+  await $("[data-test=wallet-create-open]").click();
+  await $('[data-test="wallet-create-name"]').waitForDisplayed({
+    timeout: 30000,
+  });
+  await $('[data-test="wallet-create-name"]').setValue(name);
+  await $('[data-test="wallet-create-description"]').setValue("desc");
+  await $('[data-test="wallet-create-submit"]').click();
+}
+
+Given(
+  /^There is a registered account: (\S+), and there is an wallet named: (\S+), and there is one token:(\S+) in this wallet$/,
+  async (email: string, walletName: string, tokenId: string) => {
+    const acct: SeededAccount = {
+      email,
+      password: SENDER_PASSWORD,
+      walletName,
+    };
+    senders[email] = acct;
+    // Create the Keycloak user + wallet (delete-then-create), then seed the
+    // specific token id the BDD references.
+    await seedAccount(acct, false);
+    await seedTokenIntoWalletByName(walletName, tokenId);
+    sharedTokenId = tokenId;
+  },
+);
+
+Given(/^There is one person A who has no account on Greenstand$/, async () => {
+  // No setup — person A registers later in the scenario.
+});
+
+When(
+  /^(\S+) login and click the send token button, and pick: (\S+) as sender and enable the checkbox: 'share by QR code', and input (\d+) token to send, and submit$/,
+  async (email: string, senderWallet: string, amount: string) => {
+    const acct = senders[email];
+    await loginAs(acct.email, acct.password);
+
+    // Open the send page via the bottom-nav send button.
+    await $("[data-test=bottom-nav-send]").waitForDisplayed({ timeout: 15000 });
+    await $("[data-test=bottom-nav-send]").click();
+    await $("[data-test=send-page]").waitForDisplayed({ timeout: 15000 });
+
+    // The source select defaults to the user's (only) wallet — wait for it.
+    await browser.waitUntil(
+      async () =>
+        (await $("[data-test=send-source-wallet]").getText()).includes(
+          senderWallet,
+        ),
+      {
+        timeout: 15000,
+        timeoutMsg: `sender wallet "${senderWallet}" not selected`,
+      },
+    );
+
+    // The amount field already defaults to "1" (what this scenario sends), so we
+    // don't re-type it — typing into the number field appends ("1" → "11").
+    void amount;
+
+    // Enable 'share by QR code' (hides the recipient field).
+    await $("[data-test=send-share-qr]").click();
+
+    await $("[data-test=send-submit]").click();
+  },
+);
+
+Then(/^the link shows up on the next page$/, async () => {
+  const linkEl = $("[data-test=share-link]");
+  await linkEl.waitForDisplayed({ timeout: 30000 });
+  sharedLink = (await linkEl.getText()).trim();
+  expect(sharedLink).toContain("/claim?action_token=");
+});
+
+When(/^the user A open the link$/, async () => {
+  // Isolated "second browser": drop app + Keycloak session, then open the link.
+  await clearSession();
+  await browser.url(sharedLink);
+});
+
+Then(
+  /^the user finish the registeration and login as (\S+)$/,
+  async (email: string) => {
+    // Free the Keycloak user so re-runs can register this fixed email.
+    await resetAccount(email);
+    // The /claim page auto-forwards to /signup → Keycloak registration.
+    await registerAs(email, RECEIVER_PASSWORD);
+  },
+);
+
+Then(/^the user create a wallet: (\S+)$/, async (walletName: string) => {
+  receiverWallet = walletName;
+  // Free the (globally-unique) wallet name for a clean re-run, then create it.
+  await deleteWalletByName(walletName);
+  await createWalletUI(walletName);
+});
+
+Then(/^the shared token is in the wallet$/, async () => {
+  await browser.url(`${base()}/wallet`);
+  const item = $(`[data-test=wallet-item-name-${receiverWallet}]`);
+  await item.waitForDisplayed({ timeout: 100000 });
+  await item.click();
+  await $("[data-test=wallet-details-page]").waitForDisplayed({
+    timeout: 15000,
+  });
+  await $("[data-test=token-list]").waitForDisplayed({ timeout: 15000 });
+  await browser.waitUntil(
+    async () => {
+      await browser.refresh();
+      if (!(await $("[data-test=token-list]").isDisplayed())) return false;
+      await browser.pause(2500);
+      const ids: string[] = await browser.execute(() =>
+        Array.from(document.querySelectorAll("[data-test^='token-item-']")).map(
+          e => e.getAttribute("data-test") || "",
+        ),
+      );
+      return ids.includes(`token-item-${sharedTokenId}`);
+    },
+    {
+      timeout: 90000,
+      interval: 1000,
+      timeoutMsg: `shared token ${sharedTokenId} not found in wallet ${receiverWallet}`,
+    },
+  );
+});

--- a/apps/bdd/utils/seed.ts
+++ b/apps/bdd/utils/seed.ts
@@ -25,6 +25,11 @@ const KC_REALM = process.env.PRIVATE_KEYCLOAK_REALM ?? "";
 const KC_PUBLIC_CLIENT = process.env.KEYCLOAK_PUBLIC_CLIENT_ID ?? "wallet-app-web";
 const DB_URL = process.env.WALLET_DATABASE_URL ?? "";
 const DB_SCHEMA = process.env.WALLET_DATABASE_SCHEMA ?? "wallet";
+// Local Postgres doesn't offer SSL; enable it only for remote (dev/CI) hosts.
+const DB_SSL: false | { rejectUnauthorized: boolean } =
+  /@(localhost|127\.0\.0\.1)[:/]/.test(DB_URL)
+    ? false
+    : { rejectUnauthorized: false };
 const SENDER_WALLET_ID = process.env.SENDER_WALLET_ID ?? "";
 
 export type SeededAccount = {
@@ -34,7 +39,10 @@ export type SeededAccount = {
 };
 
 // Mint an end-user access token via the Keycloak direct password grant.
-async function userToken(username: string, password: string): Promise<string> {
+export async function userToken(
+  username: string,
+  password: string,
+): Promise<string> {
   const url = `${KC_BASE}/realms/${KC_REALM}/protocol/openid-connect/token`;
   const res = await fetch(url, {
     method: "POST",
@@ -61,7 +69,7 @@ async function createWalletInDB(
 ): Promise<string> {
   const client = new Client({
     connectionString: DB_URL,
-    ssl: { rejectUnauthorized: false },
+    ssl: DB_SSL,
   });
   await client.connect();
   try {
@@ -83,7 +91,7 @@ async function createWalletInDB(
 async function createTokenInDB(walletId: string): Promise<string> {
   const client = new Client({
     connectionString: DB_URL,
-    ssl: { rejectUnauthorized: false },
+    ssl: DB_SSL,
   });
   await client.connect();
   try {
@@ -133,10 +141,10 @@ async function findUserId(
 // Destructively wipe a wallet (by its globally-unique name) and everything that
 // references it. Tokens are RE-HOMED to SENDER_WALLET_ID (not deleted) so the
 // gift pool (test-wallet-08) doesn't drain across runs. FK-safe order.
-async function deleteWalletByName(name: string): Promise<void> {
+export async function deleteWalletByName(name: string): Promise<void> {
   const client = new Client({
     connectionString: DB_URL,
-    ssl: { rejectUnauthorized: false },
+    ssl: DB_SSL,
   });
   await client.connect();
   try {
@@ -241,4 +249,84 @@ export async function seedAccount(
 // Mint a token for an already-seeded account (used by steps that query the API).
 export async function tokenFor(acct: SeededAccount): Promise<string> {
   return userToken(acct.email, acct.password);
+}
+
+// Insert one token directly into the wallet with the given (globally-unique)
+// name and return its id. The token table has no foreign keys, so a random
+// capture_id is fine. Used to fund a UI-registered sender with a shareable token
+// without depending on the wallet-api gift mechanism / a funded gift pool.
+export async function seedTokenIntoWalletByName(
+  walletName: string,
+  tokenId?: string,
+): Promise<string> {
+  const client = new Client({
+    connectionString: DB_URL,
+    ssl: DB_SSL,
+  });
+  await client.connect();
+  try {
+    await client.query(`SET search_path TO ${DB_SCHEMA}`);
+    // The wallet is created via a UI POST whose round-trip may still be in
+    // flight; poll briefly for the row before inserting.
+    let walletId: string | undefined;
+    for (let attempt = 0; attempt < 15 && !walletId; attempt++) {
+      const { rows } = await client.query(
+        "SELECT id FROM wallet WHERE name = $1",
+        [walletName],
+      );
+      if (rows.length > 0) {
+        walletId = rows[0].id;
+        break;
+      }
+      await new Promise(r => setTimeout(r, 1000));
+    }
+    if (!walletId) {
+      throw new Error(
+        `seedTokenIntoWalletByName: wallet "${walletName}" not found`,
+      );
+    }
+    const id = tokenId ?? randomUUID();
+    // A fixed token id (from the BDD) may linger from a previous run — free it,
+    // and clear any transactions referencing it, so the insert is deterministic.
+    if (tokenId) {
+      await client.query("DELETE FROM transaction WHERE token_id = $1", [id]);
+      await client.query("DELETE FROM token WHERE id = $1", [id]);
+    }
+    await client.query(
+      `INSERT INTO token (id, capture_id, wallet_id, transfer_pending, created_at, updated_at, claim)
+       VALUES ($1, $2, $3, false, NOW(), NOW(), false)`,
+      [id, randomUUID(), walletId],
+    );
+    return id;
+  } finally {
+    await client.end();
+  }
+}
+
+// Cleanup helper: delete the Keycloak user (if present) and wipe the named
+// wallet, so a UI-registered recipient can register + create that wallet fresh
+// on re-runs. Mirrors the delete half of seedAccount, without recreating.
+export async function resetAccount(
+  email: string,
+  walletName?: string,
+): Promise<void> {
+  const { access_token: adminToken } = await fetchTokenFromKeycloak();
+  // Match by email (robust: the UI registers username = email local-part, not
+  // the full email) and by username == email (seedAccount convention).
+  const byEmailRes = await fetch(
+    `${KC_BASE}/admin/realms/${KC_REALM}/users?email=${encodeURIComponent(
+      email,
+    )}&exact=true`,
+    { headers: { Authorization: `Bearer ${adminToken}` } },
+  );
+  const byEmail = (await byEmailRes.json()) as Array<{ id: string }>;
+  const ids = new Set<string>(
+    Array.isArray(byEmail) ? byEmail.map(u => u.id) : [],
+  );
+  const byUser = await findUserId(adminToken, email);
+  if (byUser) ids.add(byUser);
+  for (const id of ids) {
+    await deleteAccountFromKeycloak(adminToken, id);
+  }
+  if (walletName) await deleteWalletByName(walletName);
 }

--- a/apps/web/src/app/(protected)/send/page.tsx
+++ b/apps/web/src/app/(protected)/send/page.tsx
@@ -12,18 +12,31 @@ import {
   Alert,
   FormControlLabel,
   Checkbox,
+  Paper,
 } from "@mui/material";
-import { useGetWallets, useSendTransfer, Wallet } from "@treetracker/wallet";
+import { useAtomValue } from "jotai";
+import { tokenAtom } from "core";
+import {
+  useGetWallets,
+  useSendTransfer,
+  generateActionToken,
+  Wallet,
+} from "@treetracker/wallet";
+
+const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL ?? "";
 
 export default function SendPage() {
   const router = useRouter();
   const { wallets, isWalletLoading } = useGetWallets();
   const { sendTransfer } = useSendTransfer();
+  const authToken = useAtomValue(tokenAtom);
 
   const [sender, setSender] = useState("");
   const [recipient, setRecipient] = useState("");
   const [amount, setAmount] = useState("1");
   const [claim, setClaim] = useState(false);
+  const [shareByLink, setShareByLink] = useState(false);
+  const [shareLink, setShareLink] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
@@ -36,32 +49,73 @@ export default function SendPage() {
   }, [wallets, sender]);
 
   const amountNum = Number(amount);
-  const valid =
-    Boolean(sender) &&
-    Boolean(recipient.trim()) &&
-    Number.isInteger(amountNum) &&
-    amountNum >= 1 &&
-    recipient.trim() !== sender;
+  const amountValid = Number.isInteger(amountNum) && amountNum >= 1;
+  const valid = shareByLink
+    ? Boolean(sender) && amountValid
+    : Boolean(sender) &&
+      Boolean(recipient.trim()) &&
+      amountValid &&
+      recipient.trim() !== sender;
 
   async function onSend() {
     if (!valid || submitting) return;
     setSubmitting(true);
     setError(null);
     try {
-      await sendTransfer({
-        sender_wallet: sender,
-        receiver_wallet: recipient.trim(),
-        bundle_size: amountNum,
-        claim,
-      });
-      setSuccess(true);
-      // Give the snackbar a beat, then go to the pending list.
-      setTimeout(() => router.push("/transfers"), 1200);
+      if (shareByLink) {
+        // No receiver: issue an action token and show a claim link on the next
+        // view. Whoever opens the link claims the tokens on first wallet creation.
+        if (!authToken) throw new Error("User not authenticated");
+        const res = await generateActionToken(authToken, {
+          bundle_size: amountNum,
+          recipient_email: "link-recipient@greenstand.org",
+        });
+        const base =
+          BASE_URL ||
+          (typeof window !== "undefined" ? window.location.origin : "");
+        setShareLink(`${base}/claim?action_token=${res.action_token}`);
+      } else {
+        await sendTransfer({
+          sender_wallet: sender,
+          receiver_wallet: recipient.trim(),
+          bundle_size: amountNum,
+          claim,
+        });
+        setSuccess(true);
+        // Give the snackbar a beat, then go to the pending list.
+        setTimeout(() => router.push("/transfers"), 1200);
+      }
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to send");
     } finally {
       setSubmitting(false);
     }
+  }
+
+  // "Next page": once a link is generated, show it instead of the form.
+  if (shareLink) {
+    return (
+      <Box sx={{ p: 2 }} data-test="share-result-page">
+        <Typography variant="h6" fontWeight={600} sx={{ mb: 2 }}>
+          Share this link
+        </Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+          Anyone who opens this link can claim the tokens when they create a
+          wallet.
+        </Typography>
+        <Paper sx={{ p: 1.5, wordBreak: "break-all" }} data-test="share-link">
+          {shareLink}
+        </Paper>
+        <Button
+          variant="text"
+          onClick={() => router.push("/home")}
+          sx={{ mt: 2, color: "green" }}
+          data-test="share-done"
+        >
+          Done
+        </Button>
+      </Box>
+    );
   }
 
   return (
@@ -93,15 +147,17 @@ export default function SendPage() {
         })}
       </TextField>
 
-      <TextField
-        fullWidth
-        label="Recipient wallet"
-        placeholder="Recipient wallet name"
-        value={recipient}
-        onChange={(e) => setRecipient(e.target.value)}
-        sx={{ mb: 2 }}
-        data-test="send-recipient"
-      />
+      {!shareByLink && (
+        <TextField
+          fullWidth
+          label="Recipient wallet"
+          placeholder="Recipient wallet name"
+          value={recipient}
+          onChange={(e) => setRecipient(e.target.value)}
+          sx={{ mb: 2 }}
+          data-test="send-recipient"
+        />
+      )}
 
       <TextField
         fullWidth
@@ -114,15 +170,28 @@ export default function SendPage() {
         data-test="send-amount"
       />
 
+      {!shareByLink && (
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={claim}
+              onChange={(e) => setClaim(e.target.checked)}
+              data-test="send-claim"
+            />
+          }
+          label="Claim tokens (transfer ownership)"
+        />
+      )}
+
       <FormControlLabel
         control={
           <Checkbox
-            checked={claim}
-            onChange={(e) => setClaim(e.target.checked)}
-            data-test="send-claim"
+            checked={shareByLink}
+            onChange={(e) => setShareByLink(e.target.checked)}
+            data-test="send-share-qr"
           />
         }
-        label="Claim tokens (transfer ownership)"
+        label="Share by QR code"
       />
 
       {error && (
@@ -140,7 +209,7 @@ export default function SendPage() {
         sx={{ mt: 2, textTransform: "uppercase" }}
         data-test="send-submit"
       >
-        {submitting ? "Sending…" : "Send"}
+        {submitting ? "Sending…" : shareByLink ? "Create link" : "Send"}
       </Button>
 
       <Snackbar

--- a/apps/web/src/app/(protected)/wallet/page.tsx
+++ b/apps/web/src/app/(protected)/wallet/page.tsx
@@ -13,10 +13,21 @@ import {
 } from "@mui/material";
 import InfoIcon from "@mui/icons-material/Info";
 import AddIcon from "@mui/icons-material/Add";
+import { useAtomValue } from "jotai";
+import { tokenAtom } from "core";
 import WalletItem from "@/components/WalletItem";
 import GenericDrawer from "@/components/GenericDrawer";
 import WalletCreateDrawer from "@/components/WalletCreateDrawer";
-import { useCreateWallet, useGetWallets, Wallet } from "@treetracker/wallet";
+import {
+  useCreateWallet,
+  useGetWallets,
+  redeemActionToken,
+  Wallet,
+} from "@treetracker/wallet";
+import {
+  readPendingActionToken,
+  clearPendingActionToken,
+} from "@/utils/actionToken";
 
 export default function WalletPage() {
   const router = useRouter();
@@ -30,6 +41,7 @@ export default function WalletPage() {
   const normalize = (s: string) => s.trim().toLowerCase();
 
   const { createWallet } = useCreateWallet();
+  const authToken = useAtomValue(tokenAtom);
 
   useEffect(() => {
     if (serverWallets.length > 0) {
@@ -74,6 +86,22 @@ export default function WalletPage() {
       setNotification(
         "Thansk you for creating your wallet, we will gift you 1 token for your first wallet, please check your wallet details",
       );
+    }
+
+    // If the user arrived via a shared token link, redeem it into this wallet.
+    const pending = readPendingActionToken();
+    if (pending && authToken) {
+      try {
+        await redeemActionToken(authToken, pending);
+        clearPendingActionToken();
+        setNotification(
+          "Your shared token has been claimed and added to your wallet.",
+        );
+      } catch (e) {
+        setNotification(
+          e instanceof Error ? e.message : "Could not claim your shared token.",
+        );
+      }
     }
   };
 

--- a/apps/web/src/app/claim/page.tsx
+++ b/apps/web/src/app/claim/page.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { Suspense, useEffect, useState } from "react";
+import { useSearchParams, useRouter } from "next/navigation";
+import { Box, Typography, CircularProgress } from "@mui/material";
+import { savePendingActionToken } from "@/utils/actionToken";
+
+// Public landing for a shared token link: {BASE_URL}/claim?action_token=<jwt>.
+// The recipient may not be registered, so this route is intentionally outside
+// the (protected)/(public) auth gates. It captures the action token, then sends
+// the visitor to register; the token is redeemed on their first wallet creation.
+function Claim() {
+  const params = useSearchParams();
+  const router = useRouter();
+  const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    const actionToken = params?.get("action_token");
+    if (actionToken) {
+      savePendingActionToken(actionToken);
+      setSaved(true);
+      const t = setTimeout(() => router.replace("/signup"), 3000);
+      return () => clearTimeout(t);
+    }
+    // Nothing to claim — send to login.
+    router.replace("/login");
+    return undefined;
+  }, [params, router]);
+
+  return (
+    <Box sx={{ p: 3, textAlign: "center" }} data-test="claim-page">
+      <Typography variant="h6" fontWeight={600}>
+        You&apos;ve received tokens!
+      </Typography>
+      <Typography variant="body1" sx={{ mt: 1 }} data-test="claim-message">
+        Register and create a wallet to claim your tokens.
+      </Typography>
+      {saved && (
+        <Box sx={{ mt: 3 }} data-test="claim-saved">
+          <CircularProgress />
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+export default function ClaimPage() {
+  return (
+    <Suspense fallback={<Box sx={{ p: 3 }}>Loading…</Box>}>
+      <Claim />
+    </Suspense>
+  );
+}

--- a/apps/web/src/utils/actionToken.ts
+++ b/apps/web/src/utils/actionToken.ts
@@ -1,0 +1,27 @@
+// localStorage key holding an action token captured from a /claim link, to be
+// redeemed after the recipient registers and creates their first wallet.
+export const PENDING_ACTION_TOKEN_KEY = "pending_action_token";
+
+export function savePendingActionToken(token: string): void {
+  try {
+    localStorage.setItem(PENDING_ACTION_TOKEN_KEY, token);
+  } catch {
+    /* storage unavailable — ignore */
+  }
+}
+
+export function readPendingActionToken(): string | null {
+  try {
+    return localStorage.getItem(PENDING_ACTION_TOKEN_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function clearPendingActionToken(): void {
+  try {
+    localStorage.removeItem(PENDING_ACTION_TOKEN_KEY);
+  } catch {
+    /* ignore */
+  }
+}

--- a/packages/wallet/src/api/generateActionToken.ts
+++ b/packages/wallet/src/api/generateActionToken.ts
@@ -1,0 +1,50 @@
+import axios, { isAxiosError } from "axios";
+import { TREETRACKER_WALLET_API } from "../utils/config";
+
+// Issue a signed, expiring action token authorizing a future transfer of the
+// given tokens out of the caller's wallet. Mirrors POST /action-tokens.
+export type GenerateActionTokenInput = {
+  tokens?: string[]; // specific token ids, OR
+  bundle_size?: number; // a bundle of N generic tokens
+  recipient_email?: string; // informational (the intended recipient)
+};
+
+export type GenerateActionTokenResult = {
+  action_token: string;
+  expires_at: string;
+  token_count: number;
+};
+
+export async function generateActionToken(
+  token: string,
+  input: GenerateActionTokenInput,
+): Promise<GenerateActionTokenResult> {
+  const body =
+    input.tokens && input.tokens.length > 0
+      ? { tokens: input.tokens, recipient_email: input.recipient_email }
+      : {
+          bundle: { bundle_size: input.bundle_size },
+          recipient_email: input.recipient_email,
+        };
+
+  try {
+    const response = await axios.post(
+      `${TREETRACKER_WALLET_API}/action-tokens`,
+      body,
+      {
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+      },
+    );
+    return response.data;
+  } catch (error) {
+    if (isAxiosError(error) && error.response) {
+      const errorMessage =
+        error.response.data?.message || "Failed to generate action token";
+      throw new Error(errorMessage);
+    }
+    throw error;
+  }
+}

--- a/packages/wallet/src/api/redeemActionToken.ts
+++ b/packages/wallet/src/api/redeemActionToken.ts
@@ -1,0 +1,37 @@
+import axios, { isAxiosError } from "axios";
+import { TREETRACKER_WALLET_API } from "../utils/config";
+
+// Redeem an action token from the caller's wallet: the named tokens move from
+// the sender wallet to the caller as a single completed transfer.
+// Mirrors POST /action-tokens/redeem.
+export type RedeemActionTokenResult = {
+  state?: string;
+  parameters?: { tokens?: string[] };
+  [key: string]: unknown;
+};
+
+export async function redeemActionToken(
+  token: string,
+  actionToken: string,
+): Promise<RedeemActionTokenResult> {
+  try {
+    const response = await axios.post(
+      `${TREETRACKER_WALLET_API}/action-tokens/redeem`,
+      { action_token: actionToken },
+      {
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+      },
+    );
+    return response.data;
+  } catch (error) {
+    if (isAxiosError(error) && error.response) {
+      const errorMessage =
+        error.response.data?.message || "Failed to redeem action token";
+      throw new Error(errorMessage);
+    }
+    throw error;
+  }
+}

--- a/packages/wallet/src/index.ts
+++ b/packages/wallet/src/index.ts
@@ -9,6 +9,8 @@ export * from "./api/getTransferTokens";
 export * from "./api/acceptTransfer";
 export * from "./api/declineTransfer";
 export * from "./api/cancelTransfer";
+export * from "./api/generateActionToken";
+export * from "./api/redeemActionToken";
 export * from "./api/getTokenTransactions";
 export * from "./api/updateWallet";
 export * from "./hooks/useCreateWallet";


### PR DESCRIPTION
# Description

Share a token by link; a not-yet-registered recipient claims it on their first wallet creation.

- Sender: token details → **Share by link** → `POST /action-tokens` → link `{BASE_URL}/claim?action_token=…`
- Recipient: opens link (no login) → token saved → registers → **redeemed on first wallet creation**

Relates to: https://github.com/Greenstand/treetracker-wallet-api/issues/457
**Requires backend PR https://github.com/Greenstand/treetracker-wallet-api/pull/552 (action-token endpoints) deployed.**

## Changes Made

- [x] `apps/web` - Share-by-link (token details), public `/claim` route, redeem-on-wallet-create, `utils/actionToken.ts`
- [x] `packages/wallet` - `generateActionToken` + `redeemActionToken` wrappers
- [x] `apps/bdd` - `receive-token-by-link` feature + steps

### Type of Change
- [x] ✨ New feature (additive, non-breaking)

### How Has This Been Tested?
BDD e2e (`receive-token-by-link.feature`) - green locally; also verified by hand in the UI (two browsers).

### Checklist
- [x] Self-review
- [x] Type-check clean
- [x] Tests added (BDD e2e)
- [ ] Dependent changes merged/deployed - **blocked on wallet-api #552**
