### PR TITLE
fix(web): make app header sticky so it stays pinned on scroll (#789)

### DIFF
--- a/apps/web/src/components/header/Header.tsx
+++ b/apps/web/src/components/header/Header.tsx
@@ -123,6 +123,9 @@ export default function Header() {
     <>
       <Box
         sx={{
+          position: "sticky",
+          top: 0,
+          zIndex: (theme) => theme.zIndex.appBar,
           width: "100%",
           backgroundColor:
             pathname === "/notifications"


### PR DESCRIPTION
## What
The app header now stays pinned to the top of the viewport while the page scrolls.

## Why
Fixes #789. The outer header `Box` in `Header.tsx` had no `position` (computed `static`), so it scrolled away with the page content. The logo, title, and search/filter actions became unreachable on any scrollable page (`/settings`, `/wallet/customize`, etc.).

## Change
`apps/web/src/components/header/Header.tsx` — added to the outer header `Box`:
- `position: "sticky"`
- `top: 0`
- `zIndex: theme.zIndex.appBar`

## Testing
- Ran the app locally, logged in, opened `/settings` and scrolled — header stays pinned at the top.
- `eslint` clean on the changed file.

Closes #789