### PR TITLE
fix(web): reserve space for fixed bottom nav so page content isn't clipped (#790)

### DIFF
--- a/apps/web/src/app/(protected)/layout.tsx
+++ b/apps/web/src/app/(protected)/layout.tsx
@@ -3,6 +3,7 @@
 import { useAtom } from "jotai";
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
+import { Box } from "@mui/material";
 import LoadingSpinner from "@/components/LoadingSpinner";
 import { tokenAtom } from "core";
 import Header from "@/components/header/Header";
@@ -69,7 +70,9 @@ export default function ProtectedLayout({
     <SnackbarProvider>
       <HeaderProvider>
         <Header />
-        {children}
+        <Box sx={{ pb: "calc(56px + env(safe-area-inset-bottom))" }}>
+          {children}
+        </Box>
         <BottomNavigationBar />
       </HeaderProvider>
     </SnackbarProvider>


### PR DESCRIPTION
## What
Page content no longer hides behind the fixed bottom navigation. The scroll area now reserves room for the nav, so the last element on a page (e.g. the **Save** button on `/wallet/customize`) is fully visible and tappable.

## Why
Fixes #790. `{children}` in `(protected)/layout.tsx` was rendered between `<Header />` and the `position: fixed` `<BottomNavigationBar />` with no bottom padding, so the ~56px nav overlapped the end of scrollable content.

## Change
`apps/web/src/app/(protected)/layout.tsx` : wrapped `{children}` in a `Box` with:
- `pb: "calc(56px + env(safe-area-inset-bottom))"`

This reserves the nav's height (plus the mobile safe-area inset) at the layout level, instead of relying on each page's ad-hoc `pb`.

## Testing
- Ran locally, logged in, opened `/wallet/customize` and scrolled to the bottom, the green **Save** button now sits fully above the bottom nav.
- Checked `/settings` and `/wallet`, no awkward gap introduced.
- `eslint` clean on the changed file.

## Screenshot
<img width="2562" height="1596" alt="image" src="https://github.com/user-attachments/assets/610653ab-d75c-4d04-afb3-799c4ecf7c3b" />


Closes #790