### PR TITLE
fix(web): handle expired sessions - detect 401, notify user, fix logout (#791)

### DIFF
--- a/apps/web/src/app/(public)/login/page.tsx
+++ b/apps/web/src/app/(public)/login/page.tsx
@@ -1,23 +1,52 @@
 "use client";
 
-import { useEffect, useRef } from "react";
-import { Box } from "@mui/material";
+import { useEffect, useRef, useState } from "react";
+import { Box, Button, Stack, Alert } from "@mui/material";
 import LoadingSpinner from "@/components/LoadingSpinner";
 import { login } from "@/auth/keycloak";
 
-// Login is handled by Keycloak's hosted login page. Redirect there once on mount
-// (ref guard avoids a double redirect under React strict mode).
+// Redirect to Keycloak's hosted login on mount (ref guard avoids a double
+// redirect under strict mode). With ?expired=1, show a notice + button instead.
 export default function LoginPage() {
   const redirected = useRef(false);
+  const [expired, setExpired] = useState(false);
+
   useEffect(() => {
+    const isExpired =
+      new URLSearchParams(window.location.search).get("expired") === "1";
+    if (isExpired) {
+      setExpired(true);
+      return;
+    }
     if (redirected.current) return;
     redirected.current = true;
     login();
   }, []);
 
+  if (!expired) {
+    return (
+      <Box data-test="login-redirect">
+        <LoadingSpinner />
+      </Box>
+    );
+  }
+
   return (
-    <Box data-test="login-redirect">
-      <LoadingSpinner />
-    </Box>
+    <Stack
+      data-test="login-expired"
+      spacing={2}
+      sx={{ minHeight: "60vh", justifyContent: "center", px: 2 }}
+    >
+      <Alert severity="warning">
+        Your session is no longer valid — please log in again.
+      </Alert>
+      <Button
+        variant="contained"
+        onClick={() => login()}
+        data-test="login-again"
+      >
+        Log in again
+      </Button>
+    </Stack>
   );
 }

--- a/apps/web/src/auth/keycloak.ts
+++ b/apps/web/src/auth/keycloak.ts
@@ -45,11 +45,27 @@ export function register(): void {
 }
 
 export function logout(): void {
+  const kc = getKeycloak();
   const redirectUri =
     typeof window !== "undefined"
       ? `${window.location.origin}/login`
       : undefined;
-  getKeycloak()?.logout({ redirectUri });
+
+  // End the Keycloak session only with a live id_token; otherwise kc.logout()
+  // sends id_token_hint=undefined and Keycloak errors. Fall back to a local clear.
+  if (kc?.authenticated && kc.idToken) {
+    kc.logout({ redirectUri });
+    return;
+  }
+
+  try {
+    sessionStorage.removeItem("token");
+  } catch {
+    /* ignore */
+  }
+  if (typeof window !== "undefined") {
+    window.location.assign("/login");
+  }
 }
 
 export function accountUrl(): string | undefined {

--- a/apps/web/src/components/KeycloakProvider.tsx
+++ b/apps/web/src/components/KeycloakProvider.tsx
@@ -7,10 +7,13 @@ import {
   useState,
   ReactNode,
 } from "react";
+import axios from "axios";
 import { useSetAtom } from "jotai";
 import { tokenAtom } from "core";
 import { getKeycloak, initKeycloak } from "@/auth/keycloak";
 import LoadingSpinner from "@/components/LoadingSpinner";
+
+const WALLET_API = process.env.NEXT_PUBLIC_TREETRACKER_WALLET_API ?? "";
 
 type AuthState = { ready: boolean; authenticated: boolean };
 const KeycloakContext = createContext<AuthState>({
@@ -24,6 +27,31 @@ export function KeycloakProvider({ children }: { children: ReactNode }) {
   const setToken = useSetAtom(tokenAtom);
   const [ready, setReady] = useState(false);
   const [authenticated, setAuthenticated] = useState(false);
+
+  // On any wallet API 401 the token is no longer accepted, so clear it and send
+  // the user to /login?expired=1. Scoped to the wallet API URL; one shared axios
+  // interceptor covers every call.
+  useEffect(() => {
+    const interceptorId = axios.interceptors.response.use(
+      (response) => response,
+      (error) => {
+        const status = error?.response?.status;
+        const url = `${error?.config?.baseURL ?? ""}${error?.config?.url ?? ""}`;
+        if (status === 401 && WALLET_API && url.startsWith(WALLET_API)) {
+          try {
+            sessionStorage.removeItem("token");
+          } catch {
+            /* ignore */
+          }
+          window.location.assign("/login?expired=1");
+        }
+        return Promise.reject(error);
+      },
+    );
+    return () => {
+      axios.interceptors.response.eject(interceptorId);
+    };
+  }, []);
 
   useEffect(() => {
     let active = true;


### PR DESCRIPTION
## What
Expired sessions are now handled instead of failing silently:
- A wallet API `401` clears the stale token and sends the user to `/login` with a "session expired" notice - no more empty screen with no explanation.
- Logout no longer errors with **"Invalid parameter: id_token_hint"**.

## Why
Fixes #791. The app kept a leftover access token in `sessionStorage` and treated "a token exists" as "logged in". Once that token expired, wallet calls returned `401` but the UI just showed the empty state, and logout had no valid `id_token` to send.

## Changes
- **`components/KeycloakProvider.tsx`** - one response interceptor on the shared default `axios` instance. On a `401` from the wallet API (scoped by URL), clear the token and `assign("/login?expired=1")`. Covers all 13 wallet API calls with no change to the individual api functions.
- **`app/(public)/login/page.tsx`** - with `?expired=1`, render a notice and a **Log in again** button instead of auto-redirecting to Keycloak, so the user sees why they're back at login.
- **`auth/keycloak.ts`** - guard `logout()`: call `kc.logout()` only when a live session/`id_token` exists; otherwise clear local state and return to `/login`.

## Scope (Option A - reactive)
Any wallet-API `401` means the token is no longer accepted, so re-login is the correct recovery. This PR detects that and recovers cleanly.

**Not in this PR (follow-up, Option B):** proactive silent token renewal and full Keycloak SSO end-session on logout - both require restoring the real Keycloak session (`check-sso`), which depends on Keycloak client config we don't control here. Tracked separately. Until then, a guarded logout clears app state but may leave the Keycloak SSO cookie, so "Log in again" can re-authenticate without a password prompt.

## Testing
- `/login?expired=1` renders the notice and button, no auto-redirect, no console errors.
- Simulated an expired token (garbage `token` in `sessionStorage`) -> wallet page `401` -> redirected to `/login?expired=1` instead of the empty state.
- Logout reaches `/login` with no `id_token_hint` error.
- `eslint` and `tsc --noEmit` clean.

Closes #791