### PR TITLE
feat(wallet): show QR code of share link on send page (#802)

### DIFF
--- a/apps/bdd/features/share-token.feature
+++ b/apps/bdd/features/share-token.feature
@@ -12,7 +12,7 @@ Feature: Share Token to Others
     Then the user create a wallet: share-token-recieve-wallet-1
     Then the shared token is in the wallet
 
-  @web @skip 
+  @web
   Scenario: Share token by QR code
     Given There is a registered account: share-token-test-1@greenstand.org, and there is an wallet named: share-token-test-1-wallet, and there is one token:6593b5ff-576c-4969-86b4-7fe2aa4af1a1 in this wallet
     And There is one person A who has no account on Greenstand

--- a/apps/bdd/features/step-definitions/share-token.steps.ts
+++ b/apps/bdd/features/step-definitions/share-token.steps.ts
@@ -47,7 +47,10 @@ async function clearSession(): Promise<void> {
 }
 
 // Drive Keycloak's hosted login form, then wait for the app to load logged-in.
-async function keycloakLogin(username: string, password: string): Promise<void> {
+async function keycloakLogin(
+  username: string,
+  password: string,
+): Promise<void> {
   await $("#username").waitForDisplayed({ timeout: 25000 });
   await $("#username").setValue(username);
   await $("#password").setValue(password);
@@ -96,7 +99,9 @@ async function registerAs(email: string, password: string): Promise<void> {
 
 async function createWalletUI(name: string): Promise<void> {
   await browser.url(`${base()}/wallet`);
-  await $("[data-test=wallet-create-open]").waitForDisplayed({ timeout: 15000 });
+  await $("[data-test=wallet-create-open]").waitForDisplayed({
+    timeout: 15000,
+  });
   await $("[data-test=wallet-create-open]").click();
   await $('[data-test="wallet-create-name"]').waitForDisplayed({
     timeout: 30000,
@@ -218,4 +223,10 @@ Then(/^the shared token is in the wallet$/, async () => {
       timeoutMsg: `shared token ${sharedTokenId} not found in wallet ${receiverWallet}`,
     },
   );
+});
+
+Then(/^the QR code picture shows up on the next page$/, async () => {
+  await $("[data-test=share-qr]").waitForDisplayed({ timeout: 30000 });
+  // the QR is rendered as an inline SVG inside the container
+  await $("[data-test=share-qr] svg").waitForExist({ timeout: 10000 });
 });

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -38,6 +38,7 @@
     "jotai": "^2.9.0",
     "keycloak-js": "18.0.1",
     "next": "15.0.4",
+    "qrcode.react": "^4.2.0",
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "react-no-ssr": "1.1.0"

--- a/apps/web/src/app/(protected)/send/page.tsx
+++ b/apps/web/src/app/(protected)/send/page.tsx
@@ -14,6 +14,7 @@ import {
   Checkbox,
   Paper,
 } from "@mui/material";
+import { QRCodeSVG } from "qrcode.react";
 import { useAtomValue } from "jotai";
 import { tokenAtom } from "core";
 import {
@@ -103,6 +104,12 @@ export default function SendPage() {
           Anyone who opens this link can claim the tokens when they create a
           wallet.
         </Typography>
+        <Box
+          data-test="share-qr"
+          sx={{ display: "inline-block", p: 1.5, mb: 1, bgcolor: "#fff" }}
+        >
+          <QRCodeSVG value={shareLink} size={200} />
+        </Box>
         <Paper sx={{ p: 1.5, wordBreak: "break-all" }} data-test="share-link">
           {shareLink}
         </Paper>

--- a/yarn.lock
+++ b/yarn.lock
@@ -20822,6 +20822,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"qrcode.react@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "qrcode.react@npm:4.2.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10c0/68c691d130e5fda2f57cee505ed7aea840e7d02033100687b764601f9595e1116e34c13876628a93e1a5c2b85e4efc27d30b2fda72e2050c02f3e1c4e998d248
+  languageName: node
+  linkType: hard
+
 "qs@npm:6.11.0":
   version: 6.11.0
   resolution: "qs@npm:6.11.0"
@@ -25262,6 +25271,7 @@ __metadata:
     keycloak-js: "npm:18.0.1"
     next: "npm:15.0.4"
     prettier: "npm:^3.4.2"
+    qrcode.react: "npm:^4.2.0"
     react: "npm:19.0.0"
     react-dom: "npm:19.0.0"
     react-no-ssr: "npm:1.1.0"


### PR DESCRIPTION
# Description

Implements #802: show the token share as a **QR code**.

When "Share by QR code" is enabled on the send page, the result view now renders a QR of the claim link (`qrcode.react`) beside the existing link text. Frontend-only; builds on #794.

Closes #802

## Changes Made
- [x] `apps/web` - render `QRCodeSVG` of the claim link on the send share-result view (`send/page.tsx`); add `qrcode.react` dep
- [x] `apps/bdd` - new step `the QR code picture shows up on the next page`; un-skip the "Share token by QR code" scenario in `share-token.feature`

### Type of Change
- [x] New feature (additive, non-breaking)

### How Has This Been Tested?
BDD e2e -`share-token.feature` "Share token by QR code" passes locally (4/4); also verified by hand in the UI (QR renders and scans to the claim link).

### Checklist
- [x] Self-review
- [x] Type-check clean
- [x] Tests added (BDD e2e)
