### PR TITLE
fix: remove database connection string logging

### DIFF
--- a/packages/queue/pgClient.js
+++ b/packages/queue/pgClient.js
@@ -3,7 +3,6 @@ const log = require("loglevel");
 require("dotenv").config();
 
 const connectionString = process.env.DATABASE_URL;
-console.log(connectionString);
 if (!connectionString) {
   log.warn("DATABASE_URL is not set!");
 }


### PR DESCRIPTION
# Description

The current implementation logs the value of `DATABASE_URL` when the PostgreSQL client is initialized. Since the connection string may contain database credentials, logging it can expose sensitive information in application or CI logs.

This change removes the connection string logging while leaving the existing database connection behavior and validation unchanged.

Fixes: #804

---

## Changes Made

* [ ] Changes in **`apps`** folder

  * [ ] `Web`
  * [ ] `Native`

* [x] Changes in **`packages`** folder

  * [x] `queue` — removed logging of the PostgreSQL connection string from `pgClient.js`

---

### Type of Change

* [x] 🐛 **Bug fix** (non-breaking change which fixes an issue)
* [ ] ✨ **New feature** (non-breaking change which adds functionality)
* [ ] 💥 **Breaking change** (change that would cause existing functionality to not work as expected)
* [ ] 📝 **Documentation update** (changes)

---

#### Screenshots

Not applicable.

---

### How Has This Been Tested?

* [ ] Cypress integration
* [ ] Cypress component tests
* [ ] Jest unit tests

Additional verification:

* `node --check packages/queue/pgClient.js` — passed.
* The existing queue Jest test was run, but requires a live PostgreSQL database / `DATABASE_URL` and cannot complete in the current environment.

---

### Checklist:

* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules

---

### Additional Comments

This PR intentionally contains only the necessary change for issue #804. The existing `DATABASE_URL` validation, PostgreSQL client configuration, and connection behavior are unchanged.
