### PR TITLE
feat(notifications): add header with back and settings navigation

### DIFF
--- a/apps/native/app/(tabs)/notifications/index.tsx
+++ b/apps/native/app/(tabs)/notifications/index.tsx
@@ -1,5 +1,14 @@
 import React from "react";
-import { StyleSheet, Text, View, ScrollView, SafeAreaView } from "react-native";
+import {
+  StyleSheet,
+  Text,
+  View,
+  ScrollView,
+  SafeAreaView,
+  Pressable,
+} from "react-native";
+import { useRouter } from "expo-router";
+import { Ionicons, MaterialIcons } from "@expo/vector-icons";
 import WalletSvg from "../../../assets/svg/wallet.svg";
 
 // Mock notification data
@@ -73,7 +82,8 @@ const NotificationItem = ({
       style={[
         styles.notificationItem,
         { backgroundColor: getBackgroundColor() },
-      ]}>
+      ]}
+    >
       {/* Icon container */}
       <View style={styles.iconContainer}>
         <Text style={styles.iconText}>{notification.icon}</Text>
@@ -105,16 +115,19 @@ const EmptyState = () => (
 // Main notifications screen component
 export default function NotificationsLayout() {
   const hasNotifications = notifications.length > 0;
+  const router = useRouter();
 
   return (
     <SafeAreaView style={styles.safeArea}>
-      {/* Header - commented out because header should not be implemented but ready to be added back or replaced.
       <View style={styles.header}>
-        <Ionicons name="arrow-back" size={24} color="#666" />
+        <Pressable onPress={() => router.back()}>
+          <Ionicons name="arrow-back" size={24} color="#666" />
+        </Pressable>
         <Text style={styles.headerTitle}>Notifications</Text>
-        <Ionicons name="settings-outline" size={24} color="#666" />
+        <Pressable onPress={() => router.push("/(tabs)/settings")}>
+          <MaterialIcons name="settings" size={24} color="#666" />
+        </Pressable>
       </View>
-      */}
 
       {/* Conditional rendering: show notifications list or empty state */}
       {hasNotifications ? (
@@ -139,20 +152,21 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: "#f5f5f5",
   },
-  // Header styles
-  // header: {
-  //   flexDirection: "row",
-  //   justifyContent: "space-between",
-  //   alignItems: "center",
-  //   paddingHorizontal: 16,
-  //   paddingVertical: 12,
-  //   backgroundColor: "#f5f5f5",
-  // },
-  // headerTitle: {
-  //   fontSize: 18,
-  //   fontWeight: "600",
-  //   color: "#333",
-  // },
+  header: {
+    height: 56,
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    paddingHorizontal: 16,
+    backgroundColor: "#FFFFFF",
+  },
+  headerTitle: {
+    fontFamily: "Roboto_500Medium",
+    fontSize: 20,
+    lineHeight: 32,
+    letterSpacing: 0.15,
+    color: "rgba(34, 38, 41, 0.56)",
+  },
   scrollContainer: {
     flex: 1,
     paddingHorizontal: 16,


### PR DESCRIPTION
# Description

The notifications screen had a header stubbed out and commented out in the codebase. This PR implements it to match the Figma design, with functional back and settings navigation.

Fixes: #696

---

## Changes Made

- [x] Changes in **`apps`** folder (specify the app and briefly describe the changes):
  - [x] `Native` — Uncommented and implemented the notifications header in `app/(tabs)/notifications/index.tsx`. Added back navigation, settings navigation, and styled to Figma spec.

---

### Type of Change

- [ ] 🐛 **Bug fix** (non-breaking change which fixes an issue)
- [x] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 💥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 **Documentation update** (changes)

---

#### Screenshots

|       Before        |       After        |
| :-----------------: | :----------------: |
| <img width="523" height="1138" alt="1" src="https://github.com/user-attachments/assets/d91e2568-1843-40d8-81b6-2beec47a4c31" /> | <img width="524" height="1142" alt="2" src="https://github.com/user-attachments/assets/4f8f5646-31df-44d3-9dc5-f2519345a3a1" /> |

---

### How Has This Been Tested?

- [ ] Cypress integration
- [ ] Cypress component tests
- [ ] Jest unit tests

Manually tested on physical device via Expo Go. Verified header renders correctly, back button navigates to previous screen, and settings icon navigates to the Settings tab.

---

### Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
