### PR TITLE
fix: remove request body validation from healthz

### DIFF
--- a/apps/user/src/user/user.controller.ts
+++ b/apps/user/src/user/user.controller.ts
@@ -28,7 +28,7 @@ export class UserController {
   }
 
   @Get("healthz")
-  check(@Body() registerUserDto: RegisterUserDto) {
+  check() {
     return "tree growing!!";
   }
 


### PR DESCRIPTION
# Description

Fixes: #808

The `/healthz` endpoint was incorrectly accepting `RegisterUserDto` as a request body. Because the application uses a global validation pipe, requests to `/healthz` without registration fields were returning `400 Bad Request`.

This change removes the unnecessary request body from the health-check endpoint so it can return the expected response without requiring registration data.

---

## Changes Made

- [x] Changes in **`apps`** folder:
  - Updated `apps/user/src/user/user.controller.ts`
  - Removed `RegisterUserDto` request-body validation from the `/healthz` endpoint

- [ ] Changes in **`packages`** folder

---

### Type of Change

- [x] 🐛 **Bug fix** (non-breaking change which fixes an issue)
- [ ] ✨ **New feature**
- [ ] 💥 **Breaking change**
- [ ] 📝 **Documentation update**

---

#### Screenshots

N/A — issue was reproduced and validated using `curl`.

---

### How Has This Been Tested?

Tested locally by calling the endpoint without a request body:

```bash
curl -i http://localhost:8080/healthz