### PR TITLE
feat(native): add tooltip modal for wallet limit info icon

### DIFF
--- a/apps/native/components/wallet/CreateWalletButton.tsx
+++ b/apps/native/components/wallet/CreateWalletButton.tsx
@@ -1,7 +1,8 @@
-import React from "react";
+import React, { useState } from "react";
 import { View, Text, StyleSheet, TouchableOpacity } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import { Colors } from "@/constants/Colors";
+import CustomModal from "@/components/ui/common/CustomModal";
 
 // Component for rendering the "Create Wallet" button with info icon
 interface CreateWalletProps {
@@ -13,10 +14,7 @@ export const CreateWallet: React.FC<CreateWalletProps> = ({
   onPress,
   isActive = false,
 }) => {
-  // Placeholder for info icon functionality (can show tooltip or modal later)
-  const handleInfoPress = () => {
-    console.log("Info icon pressed"); // placeholder for now
-  };
+  const [showTooltip, setShowTooltip] = useState(false);
 
   return (
     <View style={styles.container}>
@@ -34,9 +32,30 @@ export const CreateWallet: React.FC<CreateWalletProps> = ({
       </TouchableOpacity>
 
       {/* Small info circle beside the button */}
-      <TouchableOpacity style={styles.infoCircle} onPress={handleInfoPress}>
+      <TouchableOpacity
+        style={styles.infoCircle}
+        onPress={() => setShowTooltip(true)}
+        hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+      >
         <Text style={styles.infoText}>i</Text>
       </TouchableOpacity>
+
+      <CustomModal
+        visible={showTooltip}
+        onClose={() => setShowTooltip(false)}
+        containerStyle={styles.tooltipSheet}
+      >
+        <View style={styles.tooltipHeader}>
+          <Text style={styles.tooltipTitle}>Good-to-know</Text>
+          <TouchableOpacity
+            onPress={() => setShowTooltip(false)}
+            hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+          >
+            <Ionicons name="close" size={24} color="#757575" />
+          </TouchableOpacity>
+        </View>
+        <Text style={styles.tooltipMessage}>You can have up to 2 wallets.</Text>
+      </CustomModal>
     </View>
   );
 };
@@ -75,7 +94,7 @@ const styles = StyleSheet.create({
     width: 26,
     height: 26,
     borderRadius: 13,
-    backgroundColor: "#7A7D80", // close to your gray
+    backgroundColor: "#7A7D80",
     alignItems: "center",
     justifyContent: "center",
   },
@@ -84,5 +103,27 @@ const styles = StyleSheet.create({
     fontSize: 15,
     fontWeight: "600",
     lineHeight: 17,
+  },
+  tooltipSheet: {
+    height: 180,
+  },
+  tooltipHeader: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    marginBottom: 16,
+  },
+  tooltipTitle: {
+    fontFamily: "Roboto_500Medium",
+    fontSize: 20,
+    color: "#212121",
+    lineHeight: 32,
+    letterSpacing: 0.15,
+  },
+  tooltipMessage: {
+    fontSize: 16,
+    color: "#424242",
+    lineHeight: 24,
+    letterSpacing: 0.15,
   },
 });


### PR DESCRIPTION
# Description

The info icon on the wallet screen had no functionality. This PR wires it up to display a "Good-to-know" bottom sheet tooltip informing users of the 2-wallet limit, matching the Figma design.

Fixes: #363

---

## Changes Made

- [x] Changes in **`apps`** folder (specify the app and briefly describe the changes):
  - [x] `Native` — Wired info icon in `components/wallet/CreateWalletButton.tsx` to show `CustomModal` with "Good-to-know" title and wallet limit message.

---

### Type of Change

- [ ] 🐛 **Bug fix** (non-breaking change which fixes an issue)
- [x] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 💥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 **Documentation update** (changes)

---

#### Screenshots

|       Before        |       After        |
| :-----------------: | :----------------: |
| <img width="524" height="1139" alt="1" src="https://github.com/user-attachments/assets/e4264588-d260-48f5-9044-e799ec2bfb23" /> | <img width="518" height="1141" alt="2" src="https://github.com/user-attachments/assets/8f7baac7-3a41-48cc-ba41-4d6d740882fa" />|

---

### How Has This Been Tested?

- [ ] Cypress integration
- [ ] Cypress component tests
- [ ] Jest unit tests

Manually tested on physical device via Expo Go. Verified tooltip opens on info icon tap, displays correct content, closes via × button and overlay tap.

---

### Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

---

### Additional Comments

Reused existing `CustomModal` component for consistency 
