### PR TITLE
Revert "fix(web): handle expired sessions - detect 401, notify user, fix logout (#791)"

### DIFF
--- a/apps/web/src/app/(public)/login/page.tsx
+++ b/apps/web/src/app/(public)/login/page.tsx
@@ -1,52 +1,23 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
-import { Box, Button, Stack, Alert } from "@mui/material";
+import { useEffect, useRef } from "react";
+import { Box } from "@mui/material";
 import LoadingSpinner from "@/components/LoadingSpinner";
 import { login } from "@/auth/keycloak";
 
-// Redirect to Keycloak's hosted login on mount (ref guard avoids a double
-// redirect under strict mode). With ?expired=1, show a notice + button instead.
+// Login is handled by Keycloak's hosted login page. Redirect there once on mount
+// (ref guard avoids a double redirect under React strict mode).
 export default function LoginPage() {
   const redirected = useRef(false);
-  const [expired, setExpired] = useState(false);
-
   useEffect(() => {
-    const isExpired =
-      new URLSearchParams(window.location.search).get("expired") === "1";
-    if (isExpired) {
-      setExpired(true);
-      return;
-    }
     if (redirected.current) return;
     redirected.current = true;
     login();
   }, []);
 
-  if (!expired) {
-    return (
-      <Box data-test="login-redirect">
-        <LoadingSpinner />
-      </Box>
-    );
-  }
-
   return (
-    <Stack
-      data-test="login-expired"
-      spacing={2}
-      sx={{ minHeight: "60vh", justifyContent: "center", px: 2 }}
-    >
-      <Alert severity="warning">
-        Your session is no longer valid — please log in again.
-      </Alert>
-      <Button
-        variant="contained"
-        onClick={() => login()}
-        data-test="login-again"
-      >
-        Log in again
-      </Button>
-    </Stack>
+    <Box data-test="login-redirect">
+      <LoadingSpinner />
+    </Box>
   );
 }

--- a/apps/web/src/auth/keycloak.ts
+++ b/apps/web/src/auth/keycloak.ts
@@ -45,27 +45,11 @@ export function register(): void {
 }
 
 export function logout(): void {
-  const kc = getKeycloak();
   const redirectUri =
     typeof window !== "undefined"
       ? `${window.location.origin}/login`
       : undefined;
-
-  // End the Keycloak session only with a live id_token; otherwise kc.logout()
-  // sends id_token_hint=undefined and Keycloak errors. Fall back to a local clear.
-  if (kc?.authenticated && kc.idToken) {
-    kc.logout({ redirectUri });
-    return;
-  }
-
-  try {
-    sessionStorage.removeItem("token");
-  } catch {
-    /* ignore */
-  }
-  if (typeof window !== "undefined") {
-    window.location.assign("/login");
-  }
+  getKeycloak()?.logout({ redirectUri });
 }
 
 export function accountUrl(): string | undefined {

--- a/apps/web/src/components/KeycloakProvider.tsx
+++ b/apps/web/src/components/KeycloakProvider.tsx
@@ -7,13 +7,10 @@ import {
   useState,
   ReactNode,
 } from "react";
-import axios from "axios";
 import { useSetAtom } from "jotai";
 import { tokenAtom } from "core";
 import { getKeycloak, initKeycloak } from "@/auth/keycloak";
 import LoadingSpinner from "@/components/LoadingSpinner";
-
-const WALLET_API = process.env.NEXT_PUBLIC_TREETRACKER_WALLET_API ?? "";
 
 type AuthState = { ready: boolean; authenticated: boolean };
 const KeycloakContext = createContext<AuthState>({
@@ -27,31 +24,6 @@ export function KeycloakProvider({ children }: { children: ReactNode }) {
   const setToken = useSetAtom(tokenAtom);
   const [ready, setReady] = useState(false);
   const [authenticated, setAuthenticated] = useState(false);
-
-  // On any wallet API 401 the token is no longer accepted, so clear it and send
-  // the user to /login?expired=1. Scoped to the wallet API URL; one shared axios
-  // interceptor covers every call.
-  useEffect(() => {
-    const interceptorId = axios.interceptors.response.use(
-      (response) => response,
-      (error) => {
-        const status = error?.response?.status;
-        const url = `${error?.config?.baseURL ?? ""}${error?.config?.url ?? ""}`;
-        if (status === 401 && WALLET_API && url.startsWith(WALLET_API)) {
-          try {
-            sessionStorage.removeItem("token");
-          } catch {
-            /* ignore */
-          }
-          window.location.assign("/login?expired=1");
-        }
-        return Promise.reject(error);
-      },
-    );
-    return () => {
-      axios.interceptors.response.eject(interceptorId);
-    };
-  }, []);
 
   useEffect(() => {
     let active = true;


### PR DESCRIPTION
Reverts Greenstand/treetracker-wallet-app#801


This is wrong, shouldn't clear token item when any 401 return, 401 means the request is denied because of unauthentication, it is not necessary a meaning of: the token is expired, it is possible the user is requesting the resource that is not allowed to be accessed by him/her.