### PR TITLE
test(bdd): mobile-first web BDD viewport (#813)

### DIFF
--- a/apps/bdd/utils/capabilities.ts
+++ b/apps/bdd/utils/capabilities.ts
@@ -5,16 +5,28 @@ export const CAPABILITY_WEB_CHROME = [
     // stale-element churn after the cross-origin redirect to Keycloak's pages.
     "wdio:enforceWebDriverClassic": true,
     "goog:chromeOptions": {
+      // Mobile-first: the wallet app is mobile-first, so drive the web BDD run
+      // (and its recorded videos) in an emulated iPhone viewport.
+      mobileEmulation: {
+        deviceMetrics: {
+          width: 390,
+          height: 844,
+          pixelRatio: 3,
+          mobile: true,
+          touch: true,
+        },
+        userAgent:
+          "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1",
+      },
       args: [
         "--disable-gpu",
         "--no-sandbox",
         "--disable-dev-shm-usage",
-        "--start-maximized",
         // Headless by default so CI (which has no display) can launch Chrome.
         // Set HEADED=1 locally to watch the browser while the test runs.
         // (Explicit "1" check: any non-empty env value — e.g. "0" — is truthy.)
         ...(process.env.HEADED === "1" ? [] : ["--headless=new"]),
-        "--window-size=1920,1080",
+        "--window-size=390,844",
       ],
     },
   },
@@ -27,12 +39,25 @@ export const CAPABILITY_WEB_CHROME_FOR_DEBUG = [
     // document" stale-element churn after the cross-origin redirect to Keycloak.
     "wdio:enforceWebDriverClassic": true,
     "goog:chromeOptions": {
+      // Mobile-first: match CAPABILITY_WEB_CHROME so the debug run uses the
+      // same emulated iPhone viewport as the recorded BDD run.
+      mobileEmulation: {
+        deviceMetrics: {
+          width: 390,
+          height: 844,
+          pixelRatio: 3,
+          mobile: true,
+          touch: true,
+        },
+        userAgent:
+          "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1",
+      },
       args: [
         "--disable-gpu",
-        "--start-maximized",
         "--no-sandbox",
         "--disable-dev-shm-usage",
         "--auto-open-devtools-for-tabs",
+        "--window-size=390,844",
       ],
     },
   },


### PR DESCRIPTION
## What

Make the web BDD run mobile-first: drive Chrome in an emulated iPhone viewport so the wallet app's mobile-first UI is exercised and the recorded BDD videos render as a mobile view.

## Why

Closes #813, the wallet app is mobile-first; BDD should run (and record) in a mobile viewport rather than a 1920×1080 desktop window.

## Changes

- `apps/bdd/utils/capabilities.ts`
  - Add `goog:chromeOptions.mobileEmulation` (iPhone: 390×844, `pixelRatio: 3`, `mobile`/`touch`, iOS 17 Safari UA) to both `CAPABILITY_WEB_CHROME` and `CAPABILITY_WEB_CHROME_FOR_DEBUG`.
  - Drop `--start-maximized`; set `--window-size=390,844`.
  - Native (`CAPABILITY_ANDROID` / `CAPABILITY_IOS`) already run on real devices, so the mobile-app side is unchanged.

## Testing

- `yarn bdd:e2e:local` against the local stack: videos render in the 390×844 mobile viewport.
