### PR TITLE
docs(readme): add E2E test status badge and master report link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,14 @@
 [![NestJS](https://img.shields.io/badge/NestJS-Backend-E0234E?style=flat-square&logo=nestjs)](https://nestjs.com/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5+-3178C6?style=flat-square&logo=typescript)](https://typescriptlang.org/)
 
+[![E2E Tests](https://github.com/Greenstand/treetracker-wallet-app/actions/workflows/ci-cd-pr-bdd-wallet.yml/badge.svg?branch=main)](https://github.com/Greenstand/treetracker-wallet-app/actions/workflows/ci-cd-pr-bdd-wallet.yml)
+[![Master Test Report](https://img.shields.io/badge/Master%20Test%20Report-view-brightgreen?style=flat-square)](https://greenstand.github.io/treetracker-wallet-app/webdriver/web/prod/index.html)
+
 > **Secure and user-friendly digital token management platform built by
 > Greenstand**
+
+📊 **Latest master (main branch) E2E test report:**
+[greenstand.github.io/treetracker-wallet-app/webdriver/web/prod](https://greenstand.github.io/treetracker-wallet-app/webdriver/web/prod/index.html)
 
 Greenstand offers a secure, user-friendly wallet for seamless token transfers,
 built with enterprise-grade security and a scalable monorepo architecture


### PR DESCRIPTION
# Description

Adds two links to the top of the README:

* E2E test status badge for the `main` branch.
* Direct link to the latest master E2E test report.

This makes it easy to check the test status and open the latest report without going through GitHub Actions or GitHub Pages.

The badge tracks the `PR CI BDD e2e tests` workflow on `main`, which also publishes the report.

Fixes: # (n/a)
or
Resolves: # (n/a)

---

## Changes Made

* [ ] Changes in **`apps`** folder

  * [ ] `Web`
  * [ ] `Native`

* [ ] Changes in **`packages`** folder

  * [ ] `Core`

**Other:** Root `README.md` only — added the E2E status badge and the latest master E2E report link.

---

### Type of Change

* [ ] 🐛 **Bug fix**
* [ ] ✨ **New feature**
* [ ] 💥 **Breaking change**
* [x] 📝 **Documentation update**

---

### Screenshots

| Before                      | After                                           |
| --------------------------- | ----------------------------------------------- |
| README with existing badges | README with E2E status and latest master report |

---

### How Has This Been Tested?

* [ ] Cypress integration
* [ ] Cypress component tests
* [ ] Jest unit tests

**Docs-only change — no automated tests required.**

Verified manually:

* README badges and links render correctly.
* E2E report link opens the latest master report.
* Status badge points to the correct workflow on `main`.

---

### Checklist

* [x] I have performed a self-review of my own code
* [ ] I have commented my code where needed
* [x] I have updated the documentation
* [x] My changes generate no new warnings
* [ ] I have added tests
* [ ] New and existing unit tests pass locally
* [ ] Dependent changes have been merged and published

---

### Additional Comments

The E2E status badge will show no status until the workflow runs on `main`.
The report link is available immediately.
