### PR TITLE
fix(e2e): robust send-token accept assertion, customize display-name …

### DIFF
--- a/apps/bdd/features/step-definitions/steps.ts
+++ b/apps/bdd/features/step-definitions/steps.ts
@@ -659,20 +659,32 @@ Then(/^on the (\S+) page$/, async (walletName: string) => {
   });
 });
 
-// And: the token sent by user 1 is present in the receiver wallet.
+// The receiver wallet should now contain a token.
+//
+// The wallet was empty before, so a token means the transfer was accepted.
+//
+// We check that a token exists, not its ID, because acceptance creates
+// a new token record with a different ID.
+//
+// This is the same count-based check used in the cancel scenario.
 Then(/^there is the token sent by the user 1$/, async () => {
-  const sel = `[data-test=token-item-${sendTokenReceivedTokenId}]`;
+  const countItems = () =>
+    browser.execute(
+      () => document.querySelectorAll("[data-test^='token-item-']").length,
+    );
   await browser.waitUntil(
     async () => {
-      if (await $(sel).isExisting()) return true;
+      if ((await countItems()) > 0) return true;
       await browser.refresh();
       await browser.pause(2000); // let getTokens fetch + render post-reload
-      return $(sel).isExisting();
+      return (await countItems()) > 0;
     },
     {
       timeout: 45000,
       interval: 1000,
-      timeoutMsg: `received token ${sendTokenReceivedTokenId} not found in wallet`,
+      timeoutMsg: `expected the accepted token (confirmation id: ${
+        sendTokenReceivedTokenId || "unknown"
+      }) to appear in the receiver wallet, but none found`,
     },
   );
 });

--- a/apps/web/src/app/(protected)/wallet/customize/page.tsx
+++ b/apps/web/src/app/(protected)/wallet/customize/page.tsx
@@ -143,9 +143,13 @@ function CustomizeWallet() {
       setLogoFile(null);
       setHeroFile(null);
 
-      // Redirect after 2 seconds
+      // Wait 2s, then reload the details page.
+      // A full page navigation ensures useGetWallets fetches fresh wallet data.
+      // router.push() may reuse cached data and show outdated display_name/about.
       setTimeout(() => {
-        router.push(`/wallet/details?name=${encodeURIComponent(name)}`);
+        window.location.assign(
+          `/wallet/details?name=${encodeURIComponent(name)}`,
+        );
       }, 2000);
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to update wallet");

--- a/packages/wallet/src/api/updateWallet.ts
+++ b/packages/wallet/src/api/updateWallet.ts
@@ -29,6 +29,9 @@ export async function updateWallet(
           // Let the browser set the multipart boundary; only send auth here.
           Authorization: `Bearer ${token}`,
         },
+        // Stop the request after 30s if it hangs.
+        // This shows an error instead of keeping the save spinner forever.
+        timeout: 30000,
       },
     );
     return response.data; // the updated wallet


### PR DESCRIPTION
# Description

Fixes the remaining `full-bdd-e2e-tests` failures after #806 fixed the DB-seeding (`ECONNREFUSED`) issue.

This PR fixes **3 application/test issues**. The remaining failures were caused by environment issues and were fixed separately (see **Dependencies / Context**).

### Fixes

* **Send token — Accept token transfer**

  * The test was looking for a specific token ID from the confirmation step.
  * Accepting a bundle creates a **new token record with a different ID**.
  * The test now checks that the previously empty receiver wallet contains **at least one token**.

* **Customize wallet — Update display name**

  * After saving, `router.push()` could reuse cached data and show the old `display_name` / `about`.
  * Replaced it with a **full page navigation**, forcing the details page to remount and `useGetWallets` to fetch fresh data.

* **Customize wallet — Logo / hero upload**

  * Added a **30-second timeout** to `updateWallet`.
  * If the upload request hangs, it now fails with an error instead of leaving the save spinner stuck forever.

Resolves: #<BDD e2e tracking issue>

---

## Changes Made

* [x] **`apps`**

  * [x] **Web** — `wallet/customize/page.tsx`

    * Use full-page navigation after saving.
  * [ ] Native
  * [x] **BDD** — `features/step-definitions/steps.ts`

    * Check token presence instead of a specific token ID.

* [x] **`packages`**

  * [ ] Core
  * [x] **Wallet** — `api/updateWallet.ts`

    * Added a 30-second request timeout.

---

## Type of Change

* [x] 🐛 Bug fix
* [ ] ✨ New feature
* [ ] 💥 Breaking change
* [ ] 📝 Documentation update

---

## How Has This Been Tested?

* [x] BDD end-to-end tests (WebDriverIO + Cucumber)

  * `send-token`
  * `customize-wallet`
  * `create-wallet`
  * `register`
  * `share-token`
* [x] Manual testing on dev:

  * Customize wallet → upload image → save
  * Send token → accept transfer
* [ ] Cypress integration
* [ ] Jest unit tests

---

## Checklist

* [x] Self-review completed
* [x] Added comments where needed
* [ ] Documentation updated
* [x] No new warnings
* [ ] Added/updated tests for the fixes
* [x] Existing tests pass locally
* [x] Required dependent changes are merged/published

---

## Dependencies / Context

* **Dev S3 credentials**

  * Logo/hero upload failures were caused by an invalid AWS access key in the dev `aws-s3` Kubernetes secret (`InvalidAccessKeyId`).
  * This was fixed separately. No code change is required in this PR.
