### PR TITLE
fix(web): surface wallet creation API errors instead of failing silently

### DIFF
--- a/apps/web/cypress/component/WalletCreateDrawer.cy.tsx
+++ b/apps/web/cypress/component/WalletCreateDrawer.cy.tsx
@@ -44,7 +44,7 @@ describe("WalletCreateDrawer Component", () => {
     cy.contains("Provide wallet details").should("not.exist");
   });
 
-  it('disables "Create Wallet" when name is empty/whitespace; enables when valid', () => {
+  it('disables "Create Wallet" until both name and description are filled', () => {
     mountDrawer();
 
     getCreateBtn().should("be.disabled");
@@ -53,6 +53,12 @@ describe("WalletCreateDrawer Component", () => {
     getCreateBtn().should("be.disabled");
 
     getNameInput().clear().type("My Wallet");
+    getCreateBtn().should("be.disabled");
+
+    getDescInput().type("   ");
+    getCreateBtn().should("be.disabled");
+
+    getDescInput().clear().type("A test description");
     getCreateBtn().should("not.be.disabled");
   });
 
@@ -75,6 +81,65 @@ describe("WalletCreateDrawer Component", () => {
       });
 
     cy.get("@onClose").should("have.been.calledOnce");
+  });
+
+  it("keeps the drawer open and shows the API message when onCreate rejects", () => {
+    const apiMessage = 'The wallet "test" already exists';
+    const onClose = cy.spy().as("onClose");
+    cy.mount(
+      <WalletCreateDrawer
+        open
+        onClose={onClose}
+        onCreate={() => Promise.reject(new Error(apiMessage))}
+        existingNames={[]}
+      />,
+    );
+
+    getNameInput().type("test");
+    getDescInput().type("A test description");
+    getCreateBtn().click();
+
+    getErrorHelper().should("contain.text", apiMessage);
+    cy.contains("Provide wallet details").should("exist");
+    cy.get("@onClose").should("not.have.been.called");
+  });
+
+  it("drops an error that arrives after the drawer was closed", () => {
+    let rejectCreate: (e: Error) => void = () => {};
+    const Harness = () => {
+      const [open, setOpen] = React.useState(true);
+      return (
+        <>
+          <button data-test="reopen" onClick={() => setOpen(true)}>
+            reopen
+          </button>
+          <WalletCreateDrawer
+            open={open}
+            onClose={() => setOpen(false)}
+            onCreate={() =>
+              new Promise<void>((_, reject) => {
+                rejectCreate = reject;
+              })
+            }
+            existingNames={[]}
+          />
+        </>
+      );
+    };
+
+    cy.mount(<Harness />);
+    getNameInput().type("test");
+    getDescInput().type("A test description");
+    getCreateBtn().click();
+
+    // close while the request is still in flight, then let it fail
+    getCloseBtn().click();
+    cy.contains("button", "DISCARD").click();
+    cy.then(() => rejectCreate(new Error('The wallet "test" already exists')));
+
+    cy.get('[data-test="reopen"]').click();
+    getNameInput().should("have.value", "");
+    getErrorHelper().should("not.exist");
   });
 
   it("shows duplicate helper text and disables Create when name exists (case-insensitive)", () => {

--- a/apps/web/cypress/e2e/create-wallet.cy.ts
+++ b/apps/web/cypress/e2e/create-wallet.cy.ts
@@ -37,6 +37,7 @@ describe("Wallet - Create flow (integration, all requests mocked)", () => {
     cy.getByData(SELECTORS.walletCreateOpen).click();
 
     cy.getByData(SELECTORS.walletNameInput).clear().type(name);
+    cy.getByData(SELECTORS.walletDescriptionInput).clear().type("desc");
 
     cy.intercept("POST", "**/wallets", (req) => {
       expect(req.body).to.have.property("wallet", name);
@@ -50,11 +51,43 @@ describe("Wallet - Create flow (integration, all requests mocked)", () => {
     cy.contains(name).should("exist");
   });
 
+  it("description is required: submit stays disabled until it is filled", () => {
+    cy.getByData(SELECTORS.walletCreateOpen).click();
+
+    cy.getByData(SELECTORS.walletNameInput).type("A brand new wallet");
+    cy.getByData(SELECTORS.walletCreateSubmitButton).should("be.disabled");
+
+    cy.getByData(SELECTORS.walletDescriptionInput).type("desc");
+    cy.getByData(SELECTORS.walletCreateSubmitButton).should("not.be.disabled");
+  });
+
+  it("server rejects the name: shows the API message and keeps the drawer open", () => {
+    const takenName = "test";
+    const apiMessage = `The wallet "${takenName}" already exists`;
+
+    cy.intercept("POST", "**/wallets", {
+      statusCode: 409,
+      body: { message: apiMessage },
+    }).as("createWalletConflict");
+
+    cy.getByData(SELECTORS.walletCreateOpen).click();
+    cy.getByData(SELECTORS.walletNameInput).type(takenName);
+    cy.getByData(SELECTORS.walletDescriptionInput).type("desc");
+    cy.getByData(SELECTORS.walletCreateSubmitButton).click();
+
+    cy.wait("@createWalletConflict");
+
+    cy.getByData(SELECTORS.errorHelperText).should("contain.text", apiMessage);
+    cy.getByData(SELECTORS.walletNameInput).should("be.visible");
+    cy.getByData(SELECTORS.walletList).should("not.contain.text", takenName);
+  });
+
   it("client-side duplicate check: shows helper text and disables submit", () => {
     const dupName = walletData.mocks.createdWallet.name;
 
     cy.getByData(SELECTORS.walletCreateOpen).click();
     cy.getByData(SELECTORS.walletNameInput).type(dupName);
+    cy.getByData(SELECTORS.walletDescriptionInput).type("desc");
 
     cy.intercept("POST", "**/wallets", (req) => {
       expect(req.body).to.have.property("wallet", dupName);

--- a/apps/web/cypress/support/wallet-constants.ts
+++ b/apps/web/cypress/support/wallet-constants.ts
@@ -1,6 +1,7 @@
 export const SELECTORS = {
   walletCreateOpen: "wallet-create-open",
   walletNameInput: "wallet-create-name",
+  walletDescriptionInput: "wallet-create-description",
   walletCreateSubmitButton: "wallet-create-submit",
   walletList: "wallet-list",
   errorHelperText: "error-helper-text",

--- a/apps/web/src/app/(protected)/wallet/page.tsx
+++ b/apps/web/src/app/(protected)/wallet/page.tsx
@@ -38,8 +38,6 @@ export default function WalletPage() {
   const [isCreateOpen, setIsCreateOpen] = useState(false);
   const [notification, setNotification] = useState<string | null>(null);
 
-  const normalize = (s: string) => s.trim().toLowerCase();
-
   const { createWallet } = useCreateWallet();
   const authToken = useAtomValue(tokenAtom);
 
@@ -56,9 +54,6 @@ export default function WalletPage() {
     name: string;
     description: string;
   }) => {
-    const isDup = wallets.some((w) => normalize(w.name) === normalize(name));
-    if (isDup) return;
-
     // First wallet for this user? (empty list before this creation)
     const isFirstWallet = wallets.length === 0;
 

--- a/apps/web/src/components/WalletCreateDrawer.tsx
+++ b/apps/web/src/components/WalletCreateDrawer.tsx
@@ -25,9 +25,20 @@ import CustomTextField from "@/components/common/CustomTextField";
 export interface WalletCreateDrawerProps {
   open: boolean;
   onClose: () => void;
-  onCreate: (payload: { name: string; description: string }) => void;
+  onCreate: (payload: {
+    name: string;
+    description: string;
+  }) => Promise<void> | void;
   existingNames?: string[];
 }
+
+type SubmitErrorField = "name" | "description" | "form";
+
+const fieldForMessage = (message: string): SubmitErrorField => {
+  if (/already exists|wallet can only contain/i.test(message)) return "name";
+  if (/about/i.test(message)) return "description";
+  return "form";
+};
 
 const WalletCreateDrawer: React.FC<WalletCreateDrawerProps> = ({
   open,
@@ -38,15 +49,20 @@ const WalletCreateDrawer: React.FC<WalletCreateDrawerProps> = ({
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
   const [confirmOpen, setConfirmOpen] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<{
+    field: SubmitErrorField;
+    message: string;
+  } | null>(null);
 
   const isDirty = Boolean(name.trim() || description.trim());
 
   useEffect(() => {
-    if (!open) {
-      setName("");
-      setDescription("");
-      setConfirmOpen(false);
-    }
+    setName("");
+    setDescription("");
+    setConfirmOpen(false);
+    setSubmitError(null);
+    setIsSubmitting(false);
   }, [open]);
 
   const normalize = (s: string) => s.trim().toLowerCase();
@@ -54,13 +70,27 @@ const WalletCreateDrawer: React.FC<WalletCreateDrawerProps> = ({
   const isDuplicate = useMemo(() => {
     if (!name.trim()) return false;
     const norm = normalize(name);
-    return existingNames.some(n => normalize(n) === norm);
+    return existingNames.some((n) => normalize(n) === norm);
   }, [name, existingNames]);
 
-  const handleCreate = () => {
-    if (!name.trim() || isDuplicate) return;
-    onCreate({ name: name.trim(), description: description.trim() });
-    onClose();
+  const canSubmit = Boolean(name.trim() && description.trim() && !isDuplicate);
+
+  const handleCreate = async () => {
+    if (!canSubmit || isSubmitting) return;
+    setSubmitError(null);
+    setIsSubmitting(true);
+    try {
+      await onCreate({ name: name.trim(), description: description.trim() });
+      onClose();
+    } catch (e) {
+      const message =
+        e instanceof Error && e.message
+          ? e.message
+          : "Could not create the wallet. Please try again.";
+      setSubmitError({ field: fieldForMessage(message), message });
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   const handleCloseRequest = useCallback(() => {
@@ -96,12 +126,14 @@ const WalletCreateDrawer: React.FC<WalletCreateDrawerProps> = ({
             mx: "auto",
             width: "100%",
           },
-        }}>
+        }}
+      >
         <Box sx={{ p: 2.5, pb: 1.5, display: "flex", alignItems: "center" }}>
           <Typography
             id="wallet-create-drawer-title"
             variant="h6"
-            sx={{ fontWeight: 600, flex: 1, letterSpacing: 0.2 }}>
+            sx={{ fontWeight: 600, flex: 1, letterSpacing: 0.2 }}
+          >
             Provide wallet details
           </Typography>
           <IconButton aria-label="close" onClick={handleCloseRequest}>
@@ -114,41 +146,67 @@ const WalletCreateDrawer: React.FC<WalletCreateDrawerProps> = ({
           <CustomTextField
             label="Name"
             name="name"
+            required
             placeholder="Name"
             value={name}
-            onChange={(e: ChangeEvent<HTMLInputElement>) =>
-              setName(e.target.value)
-            }
+            onChange={(e: ChangeEvent<HTMLInputElement>) => {
+              setName(e.target.value);
+              setSubmitError(null);
+            }}
             testId="wallet-create-name"
-            error={Boolean(name.trim() && isDuplicate)}
+            error={isDuplicate || submitError?.field === "name"}
             helperText={
-              isDuplicate ? "Wallet name should be unique." : undefined
+              isDuplicate
+                ? "Wallet name should be unique."
+                : submitError?.field === "name"
+                  ? submitError.message
+                  : undefined
             }
           />
 
           <CustomTextField
             label="Description"
             name="description"
+            required
             placeholder="This text will be visible when you share your wallet."
             value={description}
-            onChange={(e: ChangeEvent<HTMLInputElement>) =>
-              setDescription(e.target.value)
-            }
+            onChange={(e: ChangeEvent<HTMLInputElement>) => {
+              setDescription(e.target.value);
+              setSubmitError(null);
+            }}
             testId="wallet-create-description"
+            error={submitError?.field === "description"}
+            helperText={
+              submitError?.field === "description"
+                ? submitError.message
+                : undefined
+            }
           />
+
+          {submitError?.field === "form" && (
+            <Typography
+              variant="body2"
+              color="error"
+              data-test="wallet-create-error"
+              sx={{ mt: 0.5 }}
+            >
+              {submitError.message}
+            </Typography>
+          )}
 
           <Button
             data-test="wallet-create-submit"
             fullWidth
             size="large"
             variant="contained"
-            disabled={!name.trim() || isDuplicate}
+            disabled={!canSubmit || isSubmitting}
             onClick={handleCreate}
             sx={{
               mt: 1.5,
               ":disabled": { backgroundColor: "#E0E0E0", color: "#9E9E9E" },
               textTransform: "uppercase",
-            }}>
+            }}
+          >
             Create Wallet
           </Button>
         </Box>
@@ -157,7 +215,8 @@ const WalletCreateDrawer: React.FC<WalletCreateDrawerProps> = ({
       <Dialog
         open={confirmOpen}
         onClose={handleKeep}
-        aria-labelledby="discard-dialog-title">
+        aria-labelledby="discard-dialog-title"
+      >
         <DialogTitle id="discard-dialog-title" sx={{ fontWeight: 600 }}>
           Discard changes?
         </DialogTitle>
@@ -174,7 +233,8 @@ const WalletCreateDrawer: React.FC<WalletCreateDrawerProps> = ({
             onClick={handleDiscard}
             variant="outlined"
             color="error"
-            sx={{ fontWeight: 600 }}>
+            sx={{ fontWeight: 600 }}
+          >
             DISCARD
           </Button>
         </DialogActions>

--- a/apps/web/src/components/common/CustomTextField.tsx
+++ b/apps/web/src/components/common/CustomTextField.tsx
@@ -63,7 +63,12 @@ const CustomTextField: React.FC<CustomTextFieldProps> = memo((props) => {
         : "on";
 
   return (
-    <FormControl sx={{ width: 1, my: 2 }} variant="filled" error={!!error}>
+    <FormControl
+      sx={{ width: 1, my: 2 }}
+      variant="filled"
+      error={!!error}
+      required={required}
+    >
       <InputLabel htmlFor={inputId}>{label}</InputLabel>
       <FilledInput
         id={inputId}


### PR DESCRIPTION
## Problem

`WalletCreateDrawer` called `onCreate` without awaiting it and closed the drawer on the next line. The rejected `createWallet` promise was orphaned, so the drawer closed as if it had succeeded and the API's message (409 name taken, 422 empty about) never reached the user.

## Fix

- Await `onCreate`. Close the drawer only on success.
- Show the API message inline under the Name or Description field.
- Require both fields, keeping CREATE disabled until they are filled.

## Testing

Manual against the dev API, plus Cypress component (8) and e2e (4) specs. `yarn type-check` clean.

Closes #830
