### PR TITLE
fix(wallet): display wallet logo in list and details header

### DIFF
--- a/apps/web/src/app/(protected)/wallet/details/page.tsx
+++ b/apps/web/src/app/(protected)/wallet/details/page.tsx
@@ -11,6 +11,7 @@ import {
   Divider,
   Snackbar,
   Alert,
+  Avatar,
 } from "@mui/material";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import EditIcon from "@mui/icons-material/Edit";
@@ -62,13 +63,22 @@ function WalletDetails() {
 
       {/* Basic wallet info */}
       <Stack direction="row" alignItems="center" justifyContent="space-between">
-        <Typography
-          variant="h6"
-          fontWeight={600}
-          data-test="wallet-details-name"
-        >
-          {wallet?.display_name || name}
-        </Typography>
+        <Stack direction="row" alignItems="center" gap={1.5}>
+          <Avatar
+            src={wallet?.logo_url}
+            alt={name}
+            data-test="wallet-details-logo"
+          >
+            {name?.charAt(0).toUpperCase()}
+          </Avatar>
+          <Typography
+            variant="h6"
+            fontWeight={600}
+            data-test="wallet-details-name"
+          >
+            {wallet?.display_name || name}
+          </Typography>
+        </Stack>
         <Stack direction="row" gap={1}>
           <Button
             variant="text"

--- a/apps/web/src/components/WalletItem.tsx
+++ b/apps/web/src/components/WalletItem.tsx
@@ -1,17 +1,19 @@
 "use client";
 
 import React from "react";
-import { Box, Typography, Button, Paper } from "@mui/material";
+import { Box, Typography, Button, Paper, Avatar } from "@mui/material";
 import ChevronRightIcon from "@mui/icons-material/ChevronRight";
 
 export default function WalletItem({
   name,
   created_at,
   tokens_in_wallet,
+  logo_url,
 }: {
   name: string;
   created_at?: string | undefined;
   tokens_in_wallet?: number | undefined;
+  logo_url?: string | undefined;
 }) {
   return (
     <Paper
@@ -22,13 +24,22 @@ export default function WalletItem({
         alignItems: "center",
       }}
     >
-      <Box>
-        <Typography variant="body2" data-test={`wallet-item-name-${name}`}>
-          {name}
-        </Typography>
-        <Typography variant="body2" color="text.secondary">
-          {created_at}
-        </Typography>
+      <Box display="flex" alignItems="center" gap={2}>
+        <Avatar
+          src={logo_url}
+          alt={name}
+          data-test={`wallet-item-logo-${name}`}
+        >
+          {name?.charAt(0).toUpperCase()}
+        </Avatar>
+        <Box>
+          <Typography variant="body2" data-test={`wallet-item-name-${name}`}>
+            {name}
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            {created_at}
+          </Typography>
+        </Box>
       </Box>
 
       <Box display="flex" alignItems="center" gap={1}>

--- a/packages/wallet/src/hooks/useGetWallets.ts
+++ b/packages/wallet/src/hooks/useGetWallets.ts
@@ -29,6 +29,7 @@ export const useGetWallets = () => {
             name: w.name,
             about: w.about,
             display_name: w.display_name,
+            logo_url: w.logo_url,
             created_at: new Date(w.created_at).toLocaleString("en-US", {
               month: "long",
               day: "numeric",


### PR DESCRIPTION
### Problem
Uploaded wallet logos never appear. useGetWallets rebuilt each wallet
object and dropped logo_url, so the logo never reached the UI, and no
component rendered it.

### Fix
Include logo_url in the useGetWallets mapping. Render it as an MUI Avatar
with a first-letter fallback in the wallet list row and the details page
header. This also restores logo prefill on the customize form, which reads
the same field.

Testing
yarn type-check passes. WalletItem component spec passes.

Refs #831
