### PR TITLE
fix(wallet): display wallet cover image on details page

### DIFF
--- a/apps/web/src/app/(protected)/wallet/customize/page.tsx
+++ b/apps/web/src/app/(protected)/wallet/customize/page.tsx
@@ -55,8 +55,8 @@ function CustomizeWallet() {
       if (wallet.logo_url) {
         setLogoPreview(wallet.logo_url);
       }
-      if ((wallet as any).cover_image_url) {
-        setHeroPreview((wallet as any).cover_image_url);
+      if (wallet.cover_url) {
+        setHeroPreview(wallet.cover_url);
       }
     }
   }, [wallet]);

--- a/apps/web/src/app/(protected)/wallet/details/page.tsx
+++ b/apps/web/src/app/(protected)/wallet/details/page.tsx
@@ -61,6 +61,27 @@ function WalletDetails() {
         Back
       </Button>
 
+      {wallet?.cover_url && (
+        <Box
+          sx={{
+            mb: 2,
+            width: "100%",
+            height: 160,
+            borderRadius: 1,
+            overflow: "hidden",
+            backgroundColor: "#f0f0f0",
+          }}
+        >
+          <Box
+            component="img"
+            src={wallet.cover_url}
+            alt={`${wallet.display_name || name} cover`}
+            data-test="wallet-details-cover"
+            sx={{ width: "100%", height: "100%", objectFit: "cover" }}
+          />
+        </Box>
+      )}
+
       {/* Basic wallet info */}
       <Stack direction="row" alignItems="center" justifyContent="space-between">
         <Stack direction="row" alignItems="center" gap={1.5}>

--- a/packages/wallet/src/hooks/useGetWallets.ts
+++ b/packages/wallet/src/hooks/useGetWallets.ts
@@ -30,6 +30,7 @@ export const useGetWallets = () => {
             about: w.about,
             display_name: w.display_name,
             logo_url: w.logo_url,
+            cover_url: w.cover_url,
             created_at: new Date(w.created_at).toLocaleString("en-US", {
               month: "long",
               day: "numeric",

--- a/packages/wallet/src/types/wallet.ts
+++ b/packages/wallet/src/types/wallet.ts
@@ -4,7 +4,7 @@ export type Wallet = {
   display_name?: string;
   about?: string;
   logo_url?: string;
-  cover_image_url?: string;
+  cover_url?: string;
   created_at?: string;
   tokens_in_wallet?: number;
 };


### PR DESCRIPTION
Problem
Uploaded cover images never appear. The frontend type used cover_image_url,
a field nothing populates, useGetWallets did not map cover_url, and the
details page rendered no banner.

Fix
Rename the type field to cover_url to match the API, map cover_url in
useGetWallets, render the cover as a banner on the details page header, and
fix hero prefill on the customize form.

Depends on Greenstand/treetracker-wallet-api#557 (cover_url in GET /wallets,
issue Greenstand/treetracker-wallet-api#553) being merged and deployed to
dev.

Testing
yarn type-check passes.

Closes #831
