### PR TITLE
fix(web): align image upload limit with the API and surface the error

### DIFF
--- a/apps/bdd/features/customize-wallet.feature
+++ b/apps/bdd/features/customize-wallet.feature
@@ -36,12 +36,12 @@ Feature: Customize Wallet
     And the user is redirected to wallet details
 
   @web
-  Scenario: Reject file upload exceeding 5MB limit
+  Scenario: Reject file upload exceeding the 1MB limit
     Given There is a registered account: customize-test-4@greenstand.org, and there is an wallet named: customize-test-4-wallet
     When customize-test-4@greenstand.org login and navigate to wallet details
     And the user click the customize wallet button
     And the user try to upload a logo file with size: 6MB
-    Then an error message is shown: Logo file must be less than 5MB
+    Then an error message is shown: Logo file must be less than 1MB
     And no preview is displayed for logo
 
   @web

--- a/apps/web/src/app/(protected)/wallet/customize/page.tsx
+++ b/apps/web/src/app/(protected)/wallet/customize/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { ChangeEvent, useEffect, useState } from "react";
+import React, { ChangeEvent, useEffect, useRef, useState } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import {
   Box,
@@ -22,7 +22,10 @@ import {
 } from "@treetracker/wallet";
 import RichTextEditor from "@/components/RichTextEditor";
 
-const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+// Must match the wallet-api multer limit (server/routes/walletRouter.js).
+// Anything larger is rejected there with a 500 before it can be saved.
+const MAX_FILE_SIZE = 1000000;
+const MAX_FILE_SIZE_LABEL = "1MB";
 
 function CustomizeWallet() {
   const params = useSearchParams();
@@ -41,6 +44,7 @@ function CustomizeWallet() {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
+  const errorRef = useRef<HTMLDivElement>(null);
 
   // Resolve wallet by name
   const wallet = React.useMemo(
@@ -61,13 +65,19 @@ function CustomizeWallet() {
     }
   }, [wallet]);
 
+  // The error banner renders at the top of the page, well above the Save
+  // button and the upload controls, so on a phone it lands off-screen.
+  useEffect(() => {
+    if (error) {
+      errorRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
+    }
+  }, [error]);
+
   const handleLogoChange = (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (file) {
       if (file.size > MAX_FILE_SIZE) {
-        setError(
-          `Logo file must be less than ${MAX_FILE_SIZE / 1024 / 1024}MB`,
-        );
+        setError(`Logo file must be less than ${MAX_FILE_SIZE_LABEL}`);
         return;
       }
       if (!file.type.startsWith("image/")) {
@@ -87,9 +97,7 @@ function CustomizeWallet() {
     const file = e.target.files?.[0];
     if (file) {
       if (file.size > MAX_FILE_SIZE) {
-        setError(
-          `Hero image file must be less than ${MAX_FILE_SIZE / 1024 / 1024}MB`,
-        );
+        setError(`Hero image file must be less than ${MAX_FILE_SIZE_LABEL}`);
         return;
       }
       if (!file.type.startsWith("image/")) {
@@ -199,7 +207,12 @@ function CustomizeWallet() {
       </Typography>
 
       {error && (
-        <Alert severity="error" sx={{ mb: 2 }} data-test="customize-error">
+        <Alert
+          ref={errorRef}
+          severity="error"
+          sx={{ mb: 2 }}
+          data-test="customize-error"
+        >
           {error}
         </Alert>
       )}
@@ -289,7 +302,7 @@ function CustomizeWallet() {
             color="text.secondary"
             sx={{ display: "block", mt: 1 }}
           >
-            Max size: 5MB
+            Max size: {MAX_FILE_SIZE_LABEL}
           </Typography>
         </Box>
 
@@ -336,7 +349,7 @@ function CustomizeWallet() {
             color="text.secondary"
             sx={{ display: "block", mt: 1 }}
           >
-            Max size: 5MB
+            Max size: {MAX_FILE_SIZE_LABEL}
           </Typography>
         </Box>
 


### PR DESCRIPTION
### Problem

The Customize screen allowed 5MB and advertised "Max size: 5MB", but the wallet-api multer limit is 1,000,000 bytes. Any file between the two passed the browser check and came back as a 500 with nothing saved. The error banner does render, but it sits at the top of the page far above the Save button, so on a phone it landed off-screen and the save looked silent.


### Fix

Set MAX_FILE_SIZE to 1,000,000 to match the server exactly, and derive the on-screen text and both validation messages from a single label constant. Scroll the error banner into view whenever an error is set. Update the BDD
scenario that asserted the old 5MB message.

This honours the smaller limit rather than raising the server. Making 5MB real is a separate API change: raise multer and map MulterError LIMIT_FILE_SIZE to a 413 instead of a 500.

### Testing
Verified on a local build against the dev API: files under 1MB upload and save, larger files are rejected in the browser with a visible message. 
yarn type-check passes.

Closes #834