### PR TITLE
fix(web): resume the Keycloak session across reloads instead of looping

### DIFF
--- a/apps/web/src/app/logout/page.tsx
+++ b/apps/web/src/app/logout/page.tsx
@@ -1,19 +1,20 @@
 "use client";
 
 import { useEffect } from "react";
-import { initKeycloak, logout } from "@/auth/keycloak";
+import { clearStoredTokens, initKeycloak, logout } from "@/auth/keycloak";
 import LoadingSpinner from "@/components/LoadingSpinner";
 
 // Logs out of Keycloak (clears the SSO session) and redirects to /login.
 export default function LogoutPage() {
   useEffect(() => {
     (async () => {
-      // Clear the mirrored access token first.
+      // Clear the mirrored access token and the stored refresh pair first.
       try {
         sessionStorage.removeItem("token");
       } catch {
         /* ignore */
       }
+      clearStoredTokens();
       // Ensure Keycloak is initialized (endpoints + current session/tokens
       // loaded) BEFORE logging out — on a fresh /logout page load, calling
       // logout() before init can't build a proper end-session redirect and the

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -2,20 +2,20 @@
 
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
+import { useAuth } from "@/components/KeycloakProvider";
 import LoadingSpinner from "@/components/LoadingSpinner";
 
+// KeycloakProvider blocks rendering until init has settled, so `authenticated`
+// is already authoritative here. Reading sessionStorage directly instead raced
+// tokenAtom's async write and bounced a logged-in user to /login, which
+// re-triggered login() and looped.
 export default function Page() {
   const router = useRouter();
+  const { authenticated } = useAuth();
 
   useEffect(() => {
-    const token = sessionStorage.getItem("token");
-
-    if (token) {
-      router.replace("/home");
-    } else {
-      router.replace("/login");
-    }
-  }, [router]);
+    router.replace(authenticated ? "/home" : "/login");
+  }, [authenticated, router]);
 
   return <LoadingSpinner />;
 }

--- a/apps/web/src/auth/keycloak.ts
+++ b/apps/web/src/auth/keycloak.ts
@@ -17,6 +17,45 @@ export function getKeycloak(): Keycloak | null {
   return keycloak;
 }
 
+// sessionStorage key holding the tokens needed to resume a session across a
+// page load. Separate from the `token` key that tokenAtom owns, so the two
+// serialisations never have to agree.
+const STORED_TOKENS_KEY = "kc_tokens";
+
+type StoredTokens = { token?: string; refreshToken?: string };
+
+function readStoredTokens(): StoredTokens {
+  try {
+    const raw = sessionStorage.getItem(STORED_TOKENS_KEY);
+    return raw ? (JSON.parse(raw) as StoredTokens) : {};
+  } catch {
+    return {};
+  }
+}
+
+// Call after every successful init or refresh: Keycloak may rotate the refresh
+// token, so the stored pair has to be replaced, not just written once.
+export function saveStoredTokens(): void {
+  const kc = getKeycloak();
+  if (!kc?.token || !kc.refreshToken) return;
+  try {
+    sessionStorage.setItem(
+      STORED_TOKENS_KEY,
+      JSON.stringify({ token: kc.token, refreshToken: kc.refreshToken }),
+    );
+  } catch {
+    /* ignore */
+  }
+}
+
+export function clearStoredTokens(): void {
+  try {
+    sessionStorage.removeItem(STORED_TOKENS_KEY);
+  } catch {
+    /* ignore */
+  }
+}
+
 // Idempotent init (guards React strict-mode double invocation). Also processes the
 // OIDC authorization-code response when running on the /auth/callback URL.
 export function initKeycloak(): Promise<boolean> {
@@ -26,7 +65,20 @@ export function initKeycloak(): Promise<boolean> {
     // No `onLoad` — init must NOT trigger its own redirect (that would race the
     // explicit login()/register() redirects from the login/signup pages). init
     // still processes the OIDC code on /auth/callback regardless of onLoad.
-    initPromise = kc.init({ pkceMethod: "S256", checkLoginIframe: false });
+    // `check-sso` is not an option either: this client only whitelists
+    // /auth/callback as a redirect URI, so both the silent iframe and the
+    // redirect form are rejected by Keycloak.
+    //
+    // Instead, hand back the tokens stored by the previous page load. A parsed
+    // /auth/callback takes priority over these inside keycloak-js, so the login
+    // flow is unaffected. When they are used, keycloak-js immediately calls
+    // updateToken(-1): a live session refreshes and init resolves, a dead one
+    // rejects and KeycloakProvider clears the session.
+    initPromise = kc.init({
+      pkceMethod: "S256",
+      checkLoginIframe: false,
+      ...readStoredTokens(),
+    });
   }
   return initPromise;
 }

--- a/apps/web/src/components/KeycloakProvider.tsx
+++ b/apps/web/src/components/KeycloakProvider.tsx
@@ -9,7 +9,12 @@ import {
 } from "react";
 import { useSetAtom } from "jotai";
 import { tokenAtom } from "core";
-import { getKeycloak, initKeycloak } from "@/auth/keycloak";
+import {
+  clearStoredTokens,
+  getKeycloak,
+  initKeycloak,
+  saveStoredTokens,
+} from "@/auth/keycloak";
 import LoadingSpinner from "@/components/LoadingSpinner";
 
 type AuthState = { ready: boolean; authenticated: boolean };
@@ -20,6 +25,22 @@ const KeycloakContext = createContext<AuthState>({
 
 export const useAuth = () => useContext(KeycloakContext);
 
+// init now makes a network call (keycloak-js forces updateToken when it is
+// handed stored tokens), and the whole app is blocked behind it. If Keycloak is
+// slow or unreachable that would be an indefinite spinner, so cap the wait and
+// fall through to the login route, which is recoverable.
+const INIT_TIMEOUT_MS = 8000;
+
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error("Keycloak init timed out")),
+      ms,
+    );
+    promise.then(resolve, reject).finally(() => clearTimeout(timer));
+  });
+}
+
 export function KeycloakProvider({ children }: { children: ReactNode }) {
   const setToken = useSetAtom(tokenAtom);
   const [ready, setReady] = useState(false);
@@ -27,30 +48,49 @@ export function KeycloakProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     let active = true;
-    initKeycloak()
+
+    // The only two things that end a session: Keycloak refusing to refresh, and
+    // an explicit logout. Never an HTTP status from a resource call, which may
+    // mean "not allowed", not "expired". See the revert in #819.
+    const endSession = () => {
+      setToken(null);
+      clearStoredTokens();
+    };
+
+    withTimeout(initKeycloak(), INIT_TIMEOUT_MS)
       .then((auth) => {
         if (!active) return;
         const kc = getKeycloak();
         setAuthenticated(Boolean(auth));
         if (auth && kc?.token) {
           // Mirror the Keycloak token into tokenAtom so existing consumers
-          // (protected layout, wallet API hooks) keep working unchanged.
+          // (protected layout, wallet API hooks) keep working unchanged, and
+          // persist the pair so the next page load can resume this session.
           setToken(kc.token ?? null);
+          saveStoredTokens();
           kc.onTokenExpired = () => {
             kc.updateToken(30)
               .then((refreshed) => {
-                if (refreshed && kc.token) setToken(kc.token);
+                if (refreshed && kc.token) {
+                  setToken(kc.token);
+                  saveStoredTokens();
+                }
               })
-              .catch(() => setToken(null));
+              .catch(endSession);
           };
+        } else {
+          // Keycloak reports no session. Anything still in storage is dead, so
+          // drop it rather than let the data hooks send it and collect 401s.
+          endSession();
         }
-        // If not authenticated, leave any persisted token in place so a full-page
-        // reload (e.g. navigating directly to /wallet) keeps the session. The token
-        // is cleared explicitly on logout (/logout).
         setReady(true);
       })
       .catch(() => {
-        if (active) setReady(true);
+        // init rejects when the stored refresh token is no longer accepted, and
+        // the wrapper rejects if it takes too long to find out.
+        if (!active) return;
+        endSession();
+        setReady(true);
       });
     return () => {
       active = false;


### PR DESCRIPTION
**Draft: the storage trade-off below deserves a second opinion before this merges.**

### Problem

Reload the app and it loops through `/login`. Leave a tab idle and the wallet silently empties with 401s.

One cause: `KeycloakProvider` stored only the access token, so after a page load keycloak-js had no refresh token and kept sending a dead one. The root page made it worse by reading sessionStorage synchronously while everything else reads the async `tokenAtom`, so it saw nothing and redirected to `/login`, which calls `login()`, which came right back.

### Fix

- Persist the access and refresh token pair and hand both to `kc.init()`. A parsed `/auth/callback` still takes priority, so login is untouched, and keycloak-js then refreshes: a live session resumes, a dead one rejects.
- Cap init at 8s. It now blocks the app on a network call, so a slow Keycloak would spin forever. On timeout the session clears and `/login` bounces straight back on a live SSO cookie. *Reviewers: sanity-check that number against real dev latency.*
- End the session only on Keycloak's own verdict or that timeout. Never on an HTTP status from a resource call.
- Root page reads `useAuth()`, matching what `/auth/callback` already does.

### The decision

`onLoad: 'check-sso'` is the textbook fix and is unavailable: this client whitelists only `/auth/callback`, so both the silent iframe and the redirect form are rejected by Keycloak.

**A.** Whitelist `silent-check-sso.html` in the realm, then use check-sso. Better posture, but depends on someone else and still leans on third-party cookies.

**B.** This PR. Refresh directly against the token endpoint. No iframe, redirect, cookies, or config change. Cost: a refresh token now sits in sessionStorage, a bigger XSS target than the access token already there.

B keeps the fix self-contained. If the team prefers A, then we need the realm request instead.

### Testing

Against the dev API: reload on `/home` no longer loops; with no stored tokens, and with an expired pair seeded into sessionStorage, the session clears and routes to sign-in instead of sending a dead token; a slow token endpoint bounces through `/login` and returns rather than hanging. `yarn type-check` passes.

Closes #832
