### PR TITLE
fix(wallet): refresh the recent transfers list after accept, decline or cancel

### DIFF
--- a/apps/web/src/app/(protected)/transfers/page.tsx
+++ b/apps/web/src/app/(protected)/transfers/page.tsx
@@ -58,7 +58,11 @@ function TransferRow({
           </Typography>
         </Box>
         <Stack direction="row" alignItems="center" spacing={1}>
-          <Chip size="small" label={t.state} data-test={`transfer-state-${t.id}`} />
+          <Chip
+            size="small"
+            label={t.state}
+            data-test={`transfer-state-${t.id}`}
+          />
           {onAccept && (
             <Button
               size="small"
@@ -113,12 +117,11 @@ export default function TransfersPage() {
   const router = useRouter();
   const { wallets } = useGetWallets();
   const { transfers: pending, accept, decline, cancel } = usePendingTransfers();
-  const { transfers: history } = useGetTransfers(20);
+  const { transfers: history, reload: reloadHistory } = useGetTransfers(20);
   const [busy, setBusy] = useState(false);
 
   const myWallets = useMemo(
-    () =>
-      new Set(wallets.map((w) => (w as Wallet).name).filter(Boolean)),
+    () => new Set(wallets.map((w) => (w as Wallet).name).filter(Boolean)),
     [wallets],
   );
 
@@ -134,6 +137,8 @@ export default function TransfersPage() {
     setBusy(true);
     try {
       await fn(id);
+      // The pending hook reloads itself; the history list needs telling.
+      await reloadHistory();
     } finally {
       setBusy(false);
     }
@@ -145,7 +150,11 @@ export default function TransfersPage() {
         <Typography variant="h6" fontWeight={600}>
           Transfers
         </Typography>
-        <Button variant="text" onClick={() => router.push("/send")} sx={{ color: "green" }}>
+        <Button
+          variant="text"
+          onClick={() => router.push("/send")}
+          sx={{ color: "green" }}
+        >
           + Send
         </Button>
       </Stack>

--- a/packages/wallet/src/hooks/useGetTransfers.ts
+++ b/packages/wallet/src/hooks/useGetTransfers.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useAtomValue } from "jotai";
 import { tokenAtom } from "core";
 import { getTransfers } from "../api/getTransfers";
@@ -12,25 +12,26 @@ export const useGetTransfers = (limit: number = 5) => {
   const [isTransfersLoading, setIsTransfersLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    async function load() {
-      if (!token) {
-        setIsTransfersLoading(false);
-        return;
-      }
-      setIsTransfersLoading(true);
-      setError(null);
-      try {
-        const result = await getTransfers(token, limit);
-        setTransfers(result.transfers || []);
-      } catch (err) {
-        setError(err instanceof Error ? err.message : "Unexpected error");
-      } finally {
-        setIsTransfersLoading(false);
-      }
+  const load = useCallback(async () => {
+    if (!token) {
+      setIsTransfersLoading(false);
+      return;
     }
-    load();
+    setIsTransfersLoading(true);
+    setError(null);
+    try {
+      const result = await getTransfers(token, limit);
+      setTransfers(result.transfers || []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unexpected error");
+    } finally {
+      setIsTransfersLoading(false);
+    }
   }, [token, limit]);
 
-  return { transfers, isTransfersLoading, error };
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  return { transfers, isTransfersLoading, error, reload: load };
 };


### PR DESCRIPTION

## Problem

The Transfers page renders two lists from two independent hooks:

- `usePendingTransfers()` wraps accept/decline/cancel in `withReload`, so the pending sections refresh after an action.
- `useGetTransfers(20)` loads once on mount and exposed no `reload`, so the "Recent" list keeps rendering whatever it fetched at page load.

Result: after cancelling, the transfer disappears from "Outgoing (pending)" while the Recent list right below still labels it `pending`. Users read that as a failed cancel and retry. Only a manual refresh fixes it.

## Change

- `packages/wallet/src/hooks/useGetTransfers.ts`: move the fetch body into a `useCallback` and return `reload`, mirroring `usePendingTransfers`. Existing consumers (`home/page.tsx`, `notifications/page.tsx`) are unaffected.
- `apps/web/src/app/(protected)/transfers/page.tsx`: call `reloadHistory()` inside the shared `run()` wrapper, which already funnels all three actions, so accept, decline and cancel each refresh both lists.

## Verification

- `yarn type-check`: clean.
- `yarn lint:check`: no new findings on either file.
- Manual: send a token, cancel it; the Recent row flips to `cancelled` with no page refresh. Same for accept and decline.

Closes #833
