### PR TITLE
fix(web): add a back button to the account settings page

### DIFF
--- a/apps/web/src/app/(protected)/settings/account/page.tsx
+++ b/apps/web/src/app/(protected)/settings/account/page.tsx
@@ -8,6 +8,7 @@ import {
   CircularProgress,
   Alert,
 } from "@mui/material";
+import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import { useRouter } from "next/navigation";
 import { useAtomValue } from "jotai";
 import { tokenAtom } from "core";
@@ -89,6 +90,16 @@ export default function Account() {
         paddingBottom: "100px",
       }}
     >
+      <Button
+        variant="text"
+        startIcon={<ArrowBackIcon />}
+        onClick={() => router.push("/settings")}
+        sx={{ color: "green", alignSelf: "flex-start" }}
+        data-test="settings-account-back"
+      >
+        Back
+      </Button>
+
       {/* Account Section */}
       <Box
         sx={{


### PR DESCRIPTION

## Problem

Settings > Account was the only sub-page without a back control, unlike wallet/details, wallet/customize, notifications/details, transfers/details and token/details. On iOS Safari, with no hardware back button, the only exits were an edge swipe or the bottom nav.

## Change

One file, `apps/web/src/app/(protected)/settings/account/page.tsx`, +11 lines. Adds the same back button the other five use, routing to `/settings`. `Button` and `useRouter` were already imported, so only `ArrowBackIcon` is new.


## Verification

`yarn type-check` clean. `yarn lint:check` reports nothing on the file.

Closes #840
