### PR TITLE
feat(web): show an unread count badge on the notifications icon

### DIFF
--- a/apps/web/src/app/(protected)/notifications/page.tsx
+++ b/apps/web/src/app/(protected)/notifications/page.tsx
@@ -12,13 +12,12 @@ import {
 } from "@mui/material";
 import NotificationsOutlinedIcon from "@mui/icons-material/NotificationsOutlined";
 import { useGetWallets, useGetTransfers, Wallet } from "@treetracker/wallet";
+import LoadingSpinner from "@/components/LoadingSpinner";
 
-// Notifications = pending tokens waiting for this user to accept. Built from the
-// recent-transfers feed (same source as the home page's activity), filtered to
-// pending/requested transfers coming INTO one of the user's wallets.
+// Notifications = pending transfers into one of this user's wallets.
 export default function Notifications() {
   const router = useRouter();
-  const { wallets } = useGetWallets();
+  const { wallets, isWalletLoading } = useGetWallets();
   const { transfers, isTransfersLoading } = useGetTransfers(50);
 
   const myWallets = useMemo(
@@ -26,18 +25,15 @@ export default function Notifications() {
     [wallets],
   );
 
-  // Pending/requested transfers awaiting action. Prefer the ones coming INTO one
-  // of my wallets, but the wallet list is a separately-fetched piece of state and
-  // can lag/mismatch the transfers list — so if the incoming filter comes up empty
-  // while pending transfers exist, fall back to showing them rather than letting
-  // stale wallet state hide a real pending token.
-  const pending = transfers.filter(
-    (t) => t.state === "pending" || t.state === "requested",
+  const incoming = transfers.filter(
+    (t) =>
+      (t.state === "pending" || t.state === "requested") &&
+      t.destination_wallet &&
+      myWallets.has(t.destination_wallet),
   );
-  const incomingMatch = pending.filter(
-    (t) => t.destination_wallet && myWallets.has(t.destination_wallet),
-  );
-  const incoming = incomingMatch.length > 0 ? incomingMatch : pending;
+
+  // Wait for both fetches, or an empty list just means wallets have not loaded.
+  if (isWalletLoading || isTransfersLoading) return <LoadingSpinner />;
 
   return (
     <Container maxWidth="lg" sx={{ mt: 1 }} data-test="notifications-page">
@@ -46,7 +42,7 @@ export default function Notifications() {
       </Typography>
 
       <Stack spacing={1} data-test="notifications-list">
-        {!isTransfersLoading && incoming.length === 0 && (
+        {incoming.length === 0 && (
           <Box sx={{ textAlign: "center", color: "text.secondary", py: 6 }}>
             <NotificationsOutlinedIcon sx={{ fontSize: 48, opacity: 0.4 }} />
             <Typography variant="body2">No notifications yet.</Typography>

--- a/apps/web/src/app/(protected)/notifications/page.tsx
+++ b/apps/web/src/app/(protected)/notifications/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useMemo } from "react";
 import { useRouter } from "next/navigation";
 import {
   Container,
@@ -11,29 +10,14 @@ import {
   Avatar,
 } from "@mui/material";
 import NotificationsOutlinedIcon from "@mui/icons-material/NotificationsOutlined";
-import { useGetWallets, useGetTransfers, Wallet } from "@treetracker/wallet";
+import { useIncomingTransfers } from "@treetracker/wallet";
 import LoadingSpinner from "@/components/LoadingSpinner";
 
-// Notifications = pending transfers into one of this user's wallets.
 export default function Notifications() {
   const router = useRouter();
-  const { wallets, isWalletLoading } = useGetWallets();
-  const { transfers, isTransfersLoading } = useGetTransfers(50);
+  const { incoming, isLoading } = useIncomingTransfers();
 
-  const myWallets = useMemo(
-    () => new Set(wallets.map((w) => (w as Wallet).name).filter(Boolean)),
-    [wallets],
-  );
-
-  const incoming = transfers.filter(
-    (t) =>
-      (t.state === "pending" || t.state === "requested") &&
-      t.destination_wallet &&
-      myWallets.has(t.destination_wallet),
-  );
-
-  // Wait for both fetches, or an empty list just means wallets have not loaded.
-  if (isWalletLoading || isTransfersLoading) return <LoadingSpinner />;
+  if (isLoading) return <LoadingSpinner />;
 
   return (
     <Container maxWidth="lg" sx={{ mt: 1 }} data-test="notifications-page">

--- a/apps/web/src/components/navigation/BottomNavigatorBar.tsx
+++ b/apps/web/src/components/navigation/BottomNavigatorBar.tsx
@@ -1,17 +1,24 @@
 "use client";
 import React from "react";
-import { BottomNavigation, BottomNavigationAction, Paper } from "@mui/material";
+import {
+  Badge,
+  BottomNavigation,
+  BottomNavigationAction,
+  Paper,
+} from "@mui/material";
 import HomeIcon from "@mui/icons-material/Home";
 import SettingsIcon from "@mui/icons-material/Settings";
 import NotificationsIcon from "@mui/icons-material/NotificationsOutlined";
 import AccountBalanceWalletIcon from "@mui/icons-material/AccountBalanceWallet";
 import { useRouter } from "next/navigation";
 import Image from "next/image";
+import { useIncomingTransfers } from "@treetracker/wallet";
 
 export default function BottomNavigationBar() {
   const [value, setValue] = React.useState(0);
 
   const router = useRouter();
+  const { incoming } = useIncomingTransfers();
 
   const handleNavigation = (newValue: number) => {
     setValue(newValue);
@@ -88,7 +95,15 @@ export default function BottomNavigationBar() {
           <BottomNavigationAction
             label="Notifications"
             data-test="bottom-nav-notifications"
-            icon={<NotificationsIcon />}
+            icon={
+              <Badge
+                badgeContent={incoming.length}
+                color="error"
+                data-test="bottom-nav-notifications-badge"
+              >
+                <NotificationsIcon />
+              </Badge>
+            }
           />
           <BottomNavigationAction
             label="Settings"

--- a/packages/wallet/src/hooks/useIncomingTransfers.ts
+++ b/packages/wallet/src/hooks/useIncomingTransfers.ts
@@ -1,0 +1,25 @@
+import { useMemo } from "react";
+import { useGetWallets } from "./useGetWallets";
+import { usePendingTransfers } from "./usePendingTransfers";
+import { Wallet } from "../types/wallet";
+
+// Pending transfers addressed to one of this user's wallets, the only ones they can accept.
+export const useIncomingTransfers = () => {
+  const { wallets, isWalletLoading } = useGetWallets();
+  const { transfers, isLoading } = usePendingTransfers();
+
+  const myWallets = useMemo(
+    () => new Set(wallets.map(w => (w as Wallet).name).filter(Boolean)),
+    [wallets],
+  );
+
+  const incoming = useMemo(
+    () =>
+      transfers.filter(
+        t => t.destination_wallet && myWallets.has(t.destination_wallet),
+      ),
+    [transfers, myWallets],
+  );
+
+  return { incoming, isLoading: isWalletLoading || isLoading };
+};

--- a/packages/wallet/src/index.ts
+++ b/packages/wallet/src/index.ts
@@ -21,6 +21,7 @@ export * from "./hooks/useGetTransfers";
 export * from "./hooks/useSendTransfer";
 export * from "./hooks/useGetTransfer";
 export * from "./hooks/usePendingTransfers";
+export * from "./hooks/useIncomingTransfers";
 export * from "./hooks/useGetTokenTransactions";
 export * from "./hooks/useUpdateWallet";
 export * from "./types/wallet";


### PR DESCRIPTION
Stacked on #851. Merge that first.

## Problem

There is no way to know you have received tokens without tapping the Notifications tab and looking: the icon looks identical whether you have 0 or 10 pending tokens waiting.

## Change

New hook `packages/wallet/src/hooks/useIncomingTransfers.ts` queries pending and requested transfers by state and keeps those addressed to the user's own wallets.

- `BottomNavigatorBar.tsx`: MUI `Badge` on the icon, hidden at zero.
- `notifications/page.tsx`: same hook, so badge and list cannot disagree. Drops 19 lines.

Querying by state also removes an undercount: a pending token could previously fall outside the recent-transfers window.

## Room to optimize later

The nav mounts the hook on every protected page, costing 3 requests per navigation and 6 on `/notifications`, where nav and page fetch separately. Lifting the hook into `ProtectedLayout` would cap it at 3. Left out to keep this diff small.

The count refreshes on navigation, not in real time.

## Verification

`yarn type-check` exit 0. No new lint findings.

Closes #842
